### PR TITLE
Missing abort option + transaction for NDC texts importer

### DIFF
--- a/app/views/admin/_form_upload_ndc_texts.html.erb
+++ b/app/views/admin/_form_upload_ndc_texts.html.erb
@@ -21,6 +21,7 @@
     <th class="col" style="width:10%">Status</th>
     <th class="col" style="width:50%">Details</th>
     <th class="col" style="width:20%">Admin user</th>
+    <th class="col" style="width:10%">Action</th>
     </thead>
     <tbody>
       <% logs.each do |log| %>
@@ -37,6 +38,11 @@
             <% end %>
           </td>
           <td><%= log.user_email %></td>
+          <td>
+            <% if defined?(abort_path) && log.state == 'started' %>
+              <%= link_to 'Abort', abort_path + "?id=#{log.id}", method: :patch %>
+            <% end %>
+          </td>
         </tr>
       <% end %>
     </tbody>


### PR DESCRIPTION
The NDC importer is not using the data uploader gem to render the view, because it is slightly different (no user upload) and so needs a custom view. That  is why the abort link was missing, it was added in the gem and not in the custom view.

Additionally, I wrapped the importer in a transaction.