### PR TITLE
Feature/2020 enhancement indicator

### DIFF
--- a/app/javascript/app/components/ndcs/ndcs-enhancements-viz/ndcs-enhancements-viz-component.jsx
+++ b/app/javascript/app/components/ndcs/ndcs-enhancements-viz/ndcs-enhancements-viz-component.jsx
@@ -5,6 +5,7 @@ import { TabletLandscape } from 'components/responsive';
 import Map from 'components/map';
 import MapLegend from 'components/map-legend';
 import ButtonGroup from 'components/button-group';
+import { CheckInput } from 'cw-components';
 import Loading from 'components/loading';
 import Icon from 'components/icon';
 import infoIcon from 'assets/icons/info.svg';
@@ -12,6 +13,7 @@ import ModalMetadata from 'components/modal-metadata';
 import CircularChart from 'components/circular-chart';
 import NDCSEnhancementsTooltip from 'components/ndcs/ndcs-enhancements-viz/ndcs-enhancements-tooltip';
 import ReactTooltip from 'react-tooltip';
+import blueCheckboxTheme from 'styles/themes/checkbox/blue-checkbox.scss';
 
 import styles from './ndcs-enhancements-viz-styles.scss';
 
@@ -100,9 +102,11 @@ const NDCSEnhancementsViz = ({
   summaryData,
   handleInfoClick,
   handleCountryEnter,
-  mapColors
+  mapColors,
+  handleOnChangeChecked,
+  checked
 }) => (
-  <div>
+  <div className={styles.ndcTracker}>
     <TabletLandscape>
       {isTablet => (
         <div className={styles.wrapper}>
@@ -149,6 +153,16 @@ const NDCSEnhancementsViz = ({
                 zoomEnable
                 customCenter={!isTablet ? [10, -10] : null}
               />
+              {!loading && (
+                <div className={styles.checkboxContainer}>
+                  <CheckInput
+                    theme={blueCheckboxTheme}
+                    label="Visualize individual submissions of EU Members on the map"
+                    checked={checked}
+                    onChange={() => handleOnChangeChecked(!checked)}
+                  />
+                </div>
+              )}
               {countryData && tooltipValues && (
                 <NDCSEnhancementsTooltip
                   id={TOOLTIP_ID}
@@ -182,6 +196,8 @@ NDCSEnhancementsViz.propTypes = {
   summaryData: PropTypes.object,
   handleCountryEnter: PropTypes.func.isRequired,
   handleInfoClick: PropTypes.func.isRequired,
+  handleOnChangeChecked: PropTypes.func.isRequired,
+  checked: PropTypes.bool,
   mapColors: PropTypes.array
 };
 

--- a/app/javascript/app/components/ndcs/ndcs-enhancements-viz/ndcs-enhancements-viz-component.jsx
+++ b/app/javascript/app/components/ndcs/ndcs-enhancements-viz/ndcs-enhancements-viz-component.jsx
@@ -157,7 +157,7 @@ const NDCSEnhancementsViz = ({
                 <div className={styles.checkboxContainer}>
                   <CheckInput
                     theme={blueCheckboxTheme}
-                    label="Visualize individual submissions of EU Members on the map"
+                    label="Visualize enhanced NDCs on the map"
                     checked={checked}
                     onChange={() => handleOnChangeChecked(!checked)}
                   />

--- a/app/javascript/app/components/ndcs/ndcs-enhancements-viz/ndcs-enhancements-viz-selectors.js
+++ b/app/javascript/app/components/ndcs/ndcs-enhancements-viz/ndcs-enhancements-viz-selectors.js
@@ -289,9 +289,15 @@ export const summarizeIndicators = createSelector(
           summaryData[type].emissions.value += EUTotal - europeanLocationsValue; // To avoid double counting
           summaryData[type].countries.value +=
             europeanCountries.length - europeanLocationIsos.length; // To avoid double counting
+
           summaryData[type].includesEU = true;
         } else {
           summaryData[type].countries.value += 1;
+
+          // Enhanced 2020 should be counted as submitted 2020
+          if (type === 'enhance_2020') {
+            summaryData.submitted_2020.countries.value += 1;
+          }
 
           if (emissionsIndicator.locations[l]) {
             summaryData[type].emissions.value += parseFloat(
@@ -301,10 +307,18 @@ export const summarizeIndicators = createSelector(
         }
       }
     });
+
     Object.keys(summaryData).forEach(type => {
-      summaryData[type].emissions.value = parseFloat(
-        summaryData[type].emissions.value.toFixed(1)
-      );
+      // Enhanced 2020 should be counted as submitted 2020
+      const emissionsParsedValue =
+        type === 'submitted_2020'
+          ? parseFloat(summaryData.submitted_2020.emissions.value) +
+            parseFloat(summaryData.enhance_2020.emissions.value)
+          : parseFloat(summaryData[type].emissions.value);
+
+      summaryData[type].emissions.value = emissionsParsedValue.toFixed(1);
+    });
+    Object.keys(summaryData).forEach(type => {
       const emissionsString = `, representing <span title="2016 emissions data">${summaryData[type].emissions.value}% of global emissions</span>`;
       summaryData[type].countries.opts.label =
         {

--- a/app/javascript/app/components/ndcs/ndcs-enhancements-viz/ndcs-enhancements-viz-styles.scss
+++ b/app/javascript/app/components/ndcs/ndcs-enhancements-viz/ndcs-enhancements-viz-styles.scss
@@ -1,259 +1,267 @@
 @import '~styles/layout.scss';
 @import '~styles/settings.scss';
 
-.wrapper {
-  position: relative;
-}
+.ndcTracker {
+  .wrapper {
+    position: relative;
+  }
 
-.column {
-  @include columns();
-}
+  .column {
+    @include columns();
+  }
 
-.buttonGroup {
-  width: auto;
-  margin-top: 1em;
-  min-width: 200px;
-  float: right;
+  .buttonGroup {
+    width: auto;
+    margin-top: 1em;
+    min-width: 200px;
+    float: right;
 
-  .containerControls & {
+    .containerControls & {
+      @media #{$tablet-portrait} {
+        margin-top: 0;
+        width: 100%;
+        min-width: 0;
+      }
+    }
+  }
+
+  .containerControls {
     @media #{$tablet-portrait} {
-      margin-top: 0;
-      width: 100%;
-      min-width: 0;
+      @include columns((8,4));
     }
-  }
-}
 
-.containerControls {
-  @media #{$tablet-portrait} {
-    @include columns((8,4));
-  }
-
-  margin-bottom: 40px;
-  margin-top: 20px;
-
-  @include clearFix();
-}
-
-.searchBox {
-  @media #{$tablet-landscape} {
-    @include column-offset(9, $gutters: true);
-
+    margin-bottom: 40px;
     margin-top: 20px;
-  }
-}
 
-.legend {
-  position: absolute;
-  left: 0;
-  bottom: 12%;
-  max-width: 100%;
-
-  @media #{$tablet-portrait} {
-    max-width: 160px;
+    @include clearFix();
   }
 
-  @media #{$tablet-landscape} {
-    bottom: 0;
+  .searchBox {
+    @media #{$tablet-landscape} {
+      @include column-offset(9, $gutters: true);
+
+      margin-top: 20px;
+    }
   }
-}
 
-.summary {
-  min-height: 300px;
+  .legend {
+    position: absolute;
+    left: 0;
+    bottom: 12%;
+    max-width: 100%;
 
-  @media #{$tablet-landscape} {
+    @media #{$tablet-portrait} {
+      max-width: 160px;
+    }
+
+    @media #{$tablet-landscape} {
+      bottom: 0;
+    }
+  }
+
+  .summary {
+    min-height: 300px;
+
+    @media #{$tablet-landscape} {
+      min-height: 500px;
+    }
+  }
+
+  :global .__react_component_tooltip {
+    max-width: 250px;
+    white-space: pre-line;
+  }
+
+  .loader {
     min-height: 500px;
-  }
-}
-
-:global .__react_component_tooltip {
-  max-width: 250px;
-  white-space: pre-line;
-}
-
-.loader {
-  min-height: 500px;
-  position: absolute;
-  left: 0;
-  right: 0;
-  z-index: $z-index-loader;
-}
-
-.containerUpper,
-.containerCharts,
-.containerMap {
-  position: relative;
-}
-
-.containerMap {
-  @media #{$tablet-landscape} {
-    padding-left: calc(#{$gutter-padding} / 2);
+    position: absolute;
+    left: 0;
+    right: 0;
+    z-index: $z-index-loader;
   }
 
-  padding-top: calc(#{$gutter-padding} / 2);
+  .containerUpper,
+  .containerCharts,
+  .containerMap {
+    position: relative;
+  }
 
-  [class*=map-styles__wrapper] {
-    &,
-    &[class*=__notDraggable] {
-      cursor: default;
+  .containerMap {
+    @media #{$tablet-landscape} {
+      padding-left: calc(#{$gutter-padding} / 2);
     }
-  }
-}
 
-.containerUpper {
-  @media #{$tablet-landscape} {
-    @include columns((4,8));
-  }
-}
+    padding-top: calc(#{$gutter-padding} / 2);
 
-.containerCharts {
-  background-color: $white;
-  box-shadow: $box-shadow-light;
-
-  > div {
-    @include columns(100%);
-  }
-
-  @media #{$tablet-portrait} {
-    > div {
-      @include columns(33.333%);
+    [class*=map-styles__wrapper] {
+      &,
+      &[class*=__notDraggable] {
+        cursor: default;
+      }
     }
   }
 
-  @media #{$tablet-landscape} {
-    &,
-    > div {
-      height: 100%;
+  .containerUpper {
+    @media #{$tablet-landscape} {
+      @include columns((4,8));
     }
+  }
+
+  .containerCharts {
+    background-color: $white;
+    box-shadow: $box-shadow-light;
 
     > div {
       @include columns(100%);
     }
-  }
-}
 
-.summaryTitle {
-  font-weight: $font-weight-bold;
-  text-align: center;
-  margin-top: 20px;
-  padding-bottom: 20px;
-  cursor: default;
-}
-
-.infoIcon {
-  margin-left: 5px;
-  transform: translateY(1px);
-}
-
-.covidTooltip {
-  line-height: $line-height-medium;
-}
-
-.circularChartContainer {
-  position: relative;
-  margin: -10% 0;
-  flex: 1;
-  height: 200px;
-  overflow: visible;
-  display: flex;
-  flex-direction: row;
-  font-size: 0.8em;
-
-  > div {
-    position: relative;
-
-    &:first-child {
-      max-width: 50%;
-    }
-  }
-
-  @media #{$tablet-portrait} {
-    font-size: 1em;
-    padding-right: calc(#{$gutter-padding} / 2);
-    margin: -60px 0 6.8em;
-    flex-direction: column;
-
-    &:last-child {
-      margin-bottom: 10%;
+    @media #{$tablet-portrait} {
+      > div {
+        @include columns(33.333%);
+      }
     }
 
-    > div {
-      &:first-child {
-        max-width: 100%;
+    @media #{$tablet-landscape} {
+      &,
+      > div {
+        height: 100%;
+      }
+
+      > div {
+        @include columns(100%);
       }
     }
   }
 
-  @media #{$tablet-landscape} {
-    margin: -5% $card-content-margin 0;
-
-    &:last-child {
-      margin-bottom: -5%;
-    }
+  .summaryTitle {
+    font-weight: $font-weight-bold;
+    text-align: center;
+    margin-top: 20px;
+    padding-bottom: 20px;
+    cursor: default;
   }
 
-  @media #{$desktop} {
+  .infoIcon {
+    margin-left: 5px;
+    transform: translateY(1px);
+  }
+
+  .covidTooltip {
+    line-height: $line-height-medium;
+  }
+
+  .circularChartContainer {
+    position: relative;
+    margin: -10% 0;
+    flex: 1;
+    height: 200px;
+    overflow: visible;
+    display: flex;
     flex-direction: row;
-    margin-bottom: -10%;
+    font-size: 0.8em;
 
     > div {
+      position: relative;
+
       &:first-child {
         max-width: 50%;
       }
     }
-  }
 
-  [class*=circularChartWrapper] {
-    position: static;
-    margin: 0 auto;
-  }
+    @media #{$tablet-portrait} {
+      font-size: 1em;
+      padding-right: calc(#{$gutter-padding} / 2);
+      margin: -60px 0 6.8em;
+      flex-direction: column;
 
-  svg {
-    height: 200px !important;
-  }
+      &:last-child {
+        margin-bottom: 10%;
+      }
 
-  //Hiding circular charts for now because the number of countries will remain a small minority for some time
-  //Leaving functionality in place in case the data should be shown in the future
-  svg {
-    visibility: hidden;
+      > div {
+        &:first-child {
+          max-width: 100%;
+        }
+      }
+    }
+
+    @media #{$tablet-landscape} {
+      margin: -5% $card-content-margin 0;
+
+      &:last-child {
+        margin-bottom: -5%;
+      }
+    }
+
+    @media #{$desktop} {
+      flex-direction: row;
+      margin-bottom: -10%;
+
+      > div {
+        &:first-child {
+          max-width: 50%;
+        }
+      }
+    }
+
+    [class*=circularChartWrapper] {
+      position: static;
+      margin: 0 auto;
+    }
+
+    svg {
+      height: 200px !important;
+    }
+
+    //Hiding circular charts for now because the number of countries will remain a small minority for some time
+    //Leaving functionality in place in case the data should be shown in the future
+    svg {
+      visibility: hidden;
+    }
+
+    .circularChartValues {
+      font-size: 4.5em;
+    }
   }
 
   .circularChartValues {
-    font-size: 4.5em;
-  }
-}
-
-.circularChartValues {
-  position: absolute;
-  top: 50%;
-  left: 50%;
-  transform: translate(-50%, -50%);
-  font-weight: $font-weight-bold;
-  font-size: 2.4em;
-}
-
-.circularChartLabels {
-  position: relative;
-  display: flex;
-  align-items: center;
-  justify-content: left;
-  top: 0;
-
-  @media #{$tablet-portrait} {
-    top: -2.4em;
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    font-weight: $font-weight-bold;
+    font-size: 2.4em;
   }
 
-  @media #{$desktop} {
+  .circularChartLabels {
+    position: relative;
+    display: flex;
+    align-items: center;
+    justify-content: left;
     top: 0;
+
+    @media #{$tablet-portrait} {
+      top: -2.4em;
+    }
+
+    @media #{$desktop} {
+      top: 0;
+    }
+
+    span[title] {
+      display: inline;
+      border-bottom: 1px solid #aaa;
+      cursor: default;
+
+      &:hover {
+        border-bottom-color: #000;
+      }
+    }
   }
 
-  span[title] {
-    display: inline;
-    border-bottom: 1px solid #aaa;
-    cursor: default;
-
-    &:hover {
-      border-bottom-color: #000;
-    }
+  .checkboxContainer {
+    position: absolute;
+    left: 210px;
+    bottom: 6px;
   }
 }

--- a/app/javascript/app/components/ndcs/ndcs-enhancements-viz/ndcs-enhancements-viz.js
+++ b/app/javascript/app/components/ndcs/ndcs-enhancements-viz/ndcs-enhancements-viz.js
@@ -20,6 +20,7 @@ import {
   getISOCountries,
   getLinkToDataExplorer,
   summarizeIndicators,
+  getIsEnhancedChecked,
   MAP_COLORS
 } from './ndcs-enhancements-viz-selectors';
 
@@ -40,6 +41,7 @@ const mapStateToProps = (state, { location }) => {
     query: ndcsEnhancementsWithSelection.query,
     paths: getPathsWithStyles(ndcsEnhancementsWithSelection),
     countries: countries.data,
+    checked: getIsEnhancedChecked(ndcsEnhancementsWithSelection),
     isoCountries: getISOCountries(ndcsEnhancementsWithSelection),
     indicator: getMapIndicator(ndcsEnhancementsWithSelection),
     indicators: getIndicatorsParsed(ndcsEnhancementsWithSelection),
@@ -71,22 +73,30 @@ class NDCSEnhancementsVizContainer extends PureComponent {
     const id = isEuropeanCountry ? europeSlug : geometryIdHover;
 
     const dateIndicator = indicators.find(i => i.value === 'ndce_date');
-    const statementIndicator = indicators.find(i => i.value === 'ndce_statement');
+    const statementIndicator = indicators.find(
+      i => i.value === 'ndce_statement'
+    );
 
-    if (indicator.locations 
-      && indicator.locations[id] 
-      && indicator.locations[id].label_slug !== 'no_info_2020') {
-      let tooltipValues = {
+    if (
+      indicator.locations &&
+      indicator.locations[id] &&
+      indicator.locations[id].label_slug !== 'no_info_2020'
+    ) {
+      const tooltipValues = {
         label: this.getTooltipLabel(),
         value: undefined,
         statement: undefined,
-        note: "Learn more in table below"
+        note: 'Learn more in table below'
       };
-      if (statementIndicator.locations[id]) tooltipValues.statement = `${statementIndicator.locations[id].value}`;
-      tooltipValues.value = indicator.locations[id].label_slug === 'submitted_2020' 
-        ? `Submitted a 2020 NDC on ${dateIndicator.locations[id].value}.`
-        : `${indicator.locations[id].value}`;
-      
+
+      if (statementIndicator.locations[id]) {
+        tooltipValues.statement = `${statementIndicator.locations[id].value}`;
+      }
+      tooltipValues.value =
+        indicator.locations[id].label_slug === 'submitted_2020'
+          ? `Submitted a 2020 NDC on ${dateIndicator.locations[id].value}.`
+          : `${indicator.locations[id].value}`;
+
       return tooltipValues;
     }
     return null;
@@ -121,6 +131,10 @@ class NDCSEnhancementsVizContainer extends PureComponent {
     }
   };
 
+  handleOnChangeChecked = query => {
+    this.updateUrlParam({ name: 'showEnhancedAmbition', value: query });
+  };
+
   handleCountryEnter = geography => {
     const iso = geography.properties && geography.properties.id;
     if (iso) this.setState({ geometryIdHover: iso });
@@ -147,7 +161,8 @@ class NDCSEnhancementsVizContainer extends PureComponent {
 
   render() {
     const tooltipValues = this.getTooltipValues();
-    const { query } = this.props;
+    const { query, indicator, checked, summaryData } = this.props;
+    const { countryData } = this.state;
     const noContentMsg = query
       ? 'No results found'
       : 'There is no data for this indicator';
@@ -157,11 +172,13 @@ class NDCSEnhancementsVizContainer extends PureComponent {
       handleCountryClick: this.handleCountryClick,
       handleCountryEnter: this.handleCountryEnter,
       handleInfoClick: this.handleInfoClick,
+      handleOnChangeChecked: this.handleOnChangeChecked,
       noContentMsg,
       handleSearchChange: this.handleSearchChange,
-      indicator: this.props.indicator,
-      countryData: this.state.country,
-      summaryData: this.props.summaryData
+      checked,
+      indicator,
+      summaryData,
+      countryData
     });
   }
 }
@@ -172,6 +189,7 @@ NDCSEnhancementsVizContainer.propTypes = {
   indicator: PropTypes.object,
   indicators: PropTypes.array,
   summaryData: PropTypes.object,
+  checked: PropTypes.bool,
   location: PropTypes.object.isRequired,
   isoCountries: PropTypes.array.isRequired,
   countries: PropTypes.array,

--- a/app/javascript/app/components/ndcs/ndcs-enhancements-viz/ndcs-enhancements-viz.js
+++ b/app/javascript/app/components/ndcs/ndcs-enhancements-viz/ndcs-enhancements-viz.js
@@ -14,7 +14,7 @@ import { actions as modalActions } from 'components/modal-metadata';
 import Component from './ndcs-enhancements-viz-component';
 
 import {
-  getMapIndicator,
+  filterEnhancedValueOnIndicator,
   getIndicatorsParsed,
   getPathsWithStyles,
   getISOCountries,
@@ -43,7 +43,7 @@ const mapStateToProps = (state, { location }) => {
     countries: countries.data,
     checked: getIsEnhancedChecked(ndcsEnhancementsWithSelection),
     isoCountries: getISOCountries(ndcsEnhancementsWithSelection),
-    indicator: getMapIndicator(ndcsEnhancementsWithSelection),
+    indicator: filterEnhancedValueOnIndicator(ndcsEnhancementsWithSelection),
     indicators: getIndicatorsParsed(ndcsEnhancementsWithSelection),
     summaryData: summarizeIndicators(ndcsEnhancementsWithSelection),
     downloadLink: getLinkToDataExplorer(ndcsEnhancementsWithSelection),

--- a/app/javascript/app/components/ndcs/ndcs-explore-map/ndcs-explore-map-selectors.js
+++ b/app/javascript/app/components/ndcs/ndcs-explore-map/ndcs-explore-map-selectors.js
@@ -19,6 +19,7 @@ import {
   CATEGORY_SOURCES,
   NOT_COVERED_LABEL
 } from 'data/constants';
+import { getSubmitted2020Isos } from 'utils/indicatorCalculations';
 
 const NOT_APPLICABLE_LABEL = 'Not Applicable';
 
@@ -347,10 +348,7 @@ export const getSummaryCardData = createSelector(
     const submittedIndicator = indicators.find(
       ind => ind.slug === 'ndce_status_2020'
     );
-    if (!submittedIndicator) return null;
-    const submittedIsos = Object.keys(submittedIndicator.locations).filter(
-      iso => submittedIndicator.locations[iso].label_slug === 'submitted_2020'
-    );
+    const submittedIsos = getSubmitted2020Isos(submittedIndicator);
     if (!submittedIsos.length) return null;
     const submittedCountriesAndParties = getCountriesAndParties(submittedIsos);
 

--- a/app/javascript/app/components/ndcs/ndcs-overview-section/question-card/question-card-selectors.js
+++ b/app/javascript/app/components/ndcs/ndcs-overview-section/question-card/question-card-selectors.js
@@ -2,6 +2,7 @@ import { createSelector } from 'reselect';
 import isArray from 'lodash/isArray';
 import intersection from 'lodash/intersection';
 import { europeSlug, europeanCountries } from 'app/data/european-countries';
+import { getSubmitted2020Isos } from 'utils/indicatorCalculations';
 
 const getIndicators = state =>
   (state.ndcs && state.ndcs.data.indicators) || null;
@@ -39,13 +40,7 @@ const getSecondNDCSubmittedIsos = createSelector(
     const submittedIndicator = indicators.find(
       ind => ind.slug === 'ndce_status_2020'
     );
-    if (!submittedIndicator) return null;
-
-    const submittedIsos = Object.keys(submittedIndicator.locations).filter(
-      iso => submittedIndicator.locations[iso].label_slug === 'submitted_2020'
-    );
-
-    return submittedIsos;
+    return getSubmitted2020Isos(submittedIndicator);
   }
 );
 

--- a/app/javascript/app/utils/indicatorCalculations.js
+++ b/app/javascript/app/utils/indicatorCalculations.js
@@ -1,0 +1,10 @@
+export const getSubmitted2020Isos = submittedIndicator => {
+  if (!submittedIndicator) return null;
+  // Enhanced mitigation are a subset of submitted 2020
+  const submittedIsos = Object.keys(submittedIndicator.locations).filter(
+    iso =>
+      submittedIndicator.locations[iso].label_slug === 'submitted_2020' ||
+      submittedIndicator.locations[iso].label_slug === 'enhanced_migitation'
+  );
+  return submittedIsos;
+};


### PR DESCRIPTION
https://basecamp.com/1756858/projects/13795275/todos/432927064

- Add checkbox to 2020 tracker and show enhancements on the map only if it's on
- Update 2020 submission values as now enhanced_migitation is a subset of submitted_2020:
  + summary on 2020 ndc tracker
  + summary on ndc tracker
  + Overview (How many Parties submitted an updated or second NDC?)

NOTE: Probably the data needs a review as "73" should now be the sum of "enhanced_mitigation" and "submitted_2020" 

![image](https://user-images.githubusercontent.com/9701591/109856325-a78e8180-7c59-11eb-8aa8-ac0c96740d73.png)
![image](https://user-images.githubusercontent.com/9701591/109856966-68146500-7c5a-11eb-9903-9824aac489b0.png)
![image](https://user-images.githubusercontent.com/9701591/109857056-867a6080-7c5a-11eb-8f5b-43b7ea51f0fc.png)
