### PR TITLE
Upgrade mimemagic

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -44,7 +44,7 @@ ENV USER_REPORT_KEY $USER_REPORT_KEY
 RUN curl -sL https://deb.nodesource.com/setup_12.x | bash -
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
-        postgresql-client nodejs build-essential patch zlib1g-dev liblzma-dev libicu-dev
+       postgresql-client nodejs build-essential patch zlib1g-dev liblzma-dev libicu-dev shared-mime-info
 RUN npm install -g yarn
 
 # Create app directory

--- a/Gemfile
+++ b/Gemfile
@@ -69,6 +69,10 @@ gem 'sidekiq', '>= 6.1.0'
 gem 'listen', '>= 3.0.5', '< 3.2'
 gem 'appsignal'
 
+# 0.3.5 won't work anymore
+# https://github.com/rails/rails/issues/41750
+gem "mimemagic", '0.3.8'
+
 group :development, :test do
   gem 'dotenv-rails'
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -216,14 +216,15 @@ GEM
     marcel (0.3.3)
       mimemagic (~> 0.3.2)
     method_source (1.0.0)
-    mimemagic (0.3.5)
+    mimemagic (0.3.8)
+      nokogiri (~> 1)
     mini_mime (1.0.2)
     mini_portile2 (2.5.0)
     minitest (5.14.4)
     msgpack (1.2.4)
     multipart-post (2.0.0)
     nio4r (2.5.7)
-    nokogiri (1.11.1)
+    nokogiri (1.11.2)
       mini_portile2 (~> 2.5.0)
       racc (~> 1.4)
     oj (3.6.8)
@@ -431,6 +432,7 @@ DEPENDENCIES
   json-schema
   kaminari
   listen (>= 3.0.5, < 3.2)
+  mimemagic (= 0.3.8)
   oj
   pg (~> 0.20)
   pg_search

--- a/README.md
+++ b/README.md
@@ -52,6 +52,19 @@ yarn run rails:install
 
 These will satisfy both the frontend and backend's dependency requirements.
 
+You will probably need to install shared-mime-info in your system:
+https://github.com/rails/rails/issues/41757
+
+(mac)
+```
+brew install shared-mime-info
+```
+
+(linux)
+```
+sudo apt-get install shared-mime-info
+```
+
 #### Setting up the Rails environment
 
 Copy the sample `.env.sample` file to `.env` and modify it as needed to fit the


### PR DESCRIPTION
We can't use mimemagic 0.3.5 anymore as it has been removed and there are some license problems with 0.3.6 so we changed the version to 0.3.8

You will probably need to install shared-mime-info in your system. This is updated on the readme:
https://github.com/rails/rails/issues/41757

(mac)
```
brew install shared-mime-info
```

(linux)
```
sudo apt-get install shared-mime-info
```

https://github.com/rails/rails/issues/41750
https://github.com/rails/rails/issues/41757