### PR TITLE
Reset limits depending on data instead of source. New data bounds were still not available

### DIFF
--- a/app/javascript/app/components/ghg-emissions/ghg-emissions.js
+++ b/app/javascript/app/components/ghg-emissions/ghg-emissions.js
@@ -82,21 +82,15 @@ function GhgEmissionsContainer(props) {
   }, [dataZoomYears, data]);
 
   const previousData = usePrevious(data);
-  const previousSelected = usePrevious(selected);
 
-  // Set data limit years on URL when we don't have any years selected
+  // Set data limit years on URL when we don't have any years selected or reset when we change the data (source)
   useEffect(() => {
-    const { sourcesSelected } = selected;
-    const { sourcesSelected: previousSourcesSelected } = previousSelected || {};
-    const hasSourceChanged =
-      previousSourcesSelected &&
-      sourcesSelected.value !== previousSourcesSelected.value;
     const hasDataChanged =
       (!previousData && data) ||
       (data && data.length) !== (previousData && previousData.length);
 
     if (
-      (hasDataChanged || hasSourceChanged) &&
+      hasDataChanged &&
       data &&
       data.length &&
       (!dataZoomYears.min || !dataZoomYears.max)
@@ -108,7 +102,7 @@ function GhgEmissionsContainer(props) {
     }
 
     return undefined;
-  }, [dataZoomYears, data, selected.sourcesSelected]);
+  }, [dataZoomYears, data]);
 
   useEffect(() => {
     const { sourcesSelected } = selected;


### PR DESCRIPTION
Reset limits depending on data instead of source. New data bounds were still not available

Try: Change source on GHG emissions chart. The years should adapt to the real first year of the new source