### PR TITLE
Feature/GHG targets with ndc documents

### DIFF
--- a/app/controllers/api/v1/quantifications_controller.rb
+++ b/app/controllers/api/v1/quantifications_controller.rb
@@ -4,9 +4,11 @@ module Api
       def index
         values = ::Quantification::Value.includes(:location, :label)
         values = values.where(locations: {iso_code3: locations}) if locations
+        latest_submissions = ::Indc::Submission.latest_per_location.includes(:document).group_by(&:location)
 
         render json: values,
-               each_serializer: Api::V1::Quantification::ValueSerializer
+               each_serializer: Api::V1::Quantification::ValueSerializer,
+               latest_submissions: latest_submissions
       end
 
       private

--- a/app/models/quantification/value.rb
+++ b/app/models/quantification/value.rb
@@ -2,14 +2,15 @@
 #
 # Table name: quantification_values
 #
-#  id           :bigint           not null, primary key
-#  location_id  :bigint
-#  label_id     :bigint
-#  year         :integer
-#  first_value  :float
-#  created_at   :datetime         not null
-#  updated_at   :datetime         not null
-#  second_value :float
+#  id            :bigint           not null, primary key
+#  location_id   :bigint
+#  label_id      :bigint
+#  year          :integer
+#  first_value   :float
+#  created_at    :datetime         not null
+#  updated_at    :datetime         not null
+#  second_value  :float
+#  document_slug :string
 #
 module Quantification
   class Value < ApplicationRecord

--- a/app/serializers/api/v1/quantification/value_serializer.rb
+++ b/app/serializers/api/v1/quantification/value_serializer.rb
@@ -6,6 +6,7 @@ module Api
         attribute :year
         attribute :value
         attribute :label
+        attribute :document_slug
 
         def location
           object.location.iso_code3

--- a/app/serializers/api/v1/quantification/value_serializer.rb
+++ b/app/serializers/api/v1/quantification/value_serializer.rb
@@ -7,6 +7,7 @@ module Api
         attribute :value
         attribute :label
         attribute :document_slug
+        attribute :latest
 
         def location
           object.location.iso_code3
@@ -22,6 +23,13 @@ module Api
           elsif object.first_value.present? && object.second_value.present?
             [object.first_value, object.second_value]
           end
+        end
+
+        def latest
+          return unless instance_options[:latest_submissions].present?
+
+          instance_options[:latest_submissions][object.location]&.first&.document&.slug ==
+            object.document_slug
         end
       end
     end

--- a/app/services/import_quantifications.rb
+++ b/app/services/import_quantifications.rb
@@ -27,9 +27,6 @@ class ImportQuantifications
       location = Location.find_by(iso_code3: row[:iso])
       label = Quantification::Label.find_or_create_by!(name: row[:label])
 
-      # TODO: clarify the data
-      next if row[:year].blank?
-
       if location
         if row[:range] == 'Yes'
           value = Quantification::Value.find_or_initialize_by(

--- a/app/services/import_quantifications.rb
+++ b/app/services/import_quantifications.rb
@@ -26,9 +26,14 @@ class ImportQuantifications
     @csv.each do |row|
       location = Location.find_by(iso_code3: row[:iso])
       label = Quantification::Label.find_or_create_by!(name: row[:label])
+
+      # TODO: clarify the data
+      next if row[:year].blank?
+
       if location
         if row[:range] == 'Yes'
           value = Quantification::Value.find_or_initialize_by(
+            document_slug: row[:document]&.parameterize&.gsub('-', '_'),
             location: location,
             label: label,
             year: row[:year],
@@ -40,6 +45,7 @@ class ImportQuantifications
           value.update!(first_value: range.first, second_value: range.second)
         else
           Quantification::Value.create!(
+            document_slug: row[:document]&.parameterize&.gsub('-', '_'),
             location: location,
             label: label,
             year: row[:year],

--- a/db/migrate/20220527093456_add_document_slug_to_quantification_values.rb
+++ b/db/migrate/20220527093456_add_document_slug_to_quantification_values.rb
@@ -1,0 +1,5 @@
+class AddDocumentSlugToQuantificationValues < ActiveRecord::Migration[5.2]
+  def change
+    add_column :quantification_values, :document_slug, :string
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -1756,7 +1756,8 @@ CREATE TABLE public.quantification_values (
     first_value double precision,
     created_at timestamp without time zone NOT NULL,
     updated_at timestamp without time zone NOT NULL,
-    second_value double precision
+    second_value double precision,
+    document_slug character varying
 );
 
 
@@ -4791,6 +4792,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20220420150714'),
 ('20220420152331'),
 ('20220519084239'),
-('20220520090514');
+('20220520090514'),
+('20220527093456');
 
 

--- a/spec/factories/quantification_values.rb
+++ b/spec/factories/quantification_values.rb
@@ -2,14 +2,15 @@
 #
 # Table name: quantification_values
 #
-#  id           :bigint           not null, primary key
-#  location_id  :bigint
-#  label_id     :bigint
-#  year         :integer
-#  first_value  :float
-#  created_at   :datetime         not null
-#  updated_at   :datetime         not null
-#  second_value :float
+#  id            :bigint           not null, primary key
+#  location_id   :bigint
+#  label_id      :bigint
+#  year          :integer
+#  first_value   :float
+#  created_at    :datetime         not null
+#  updated_at    :datetime         not null
+#  second_value  :float
+#  document_slug :string
 #
 FactoryBot.define do
   factory :quantification_value, class: 'Quantification::Value' do

--- a/spec/models/quantification/value_spec.rb
+++ b/spec/models/quantification/value_spec.rb
@@ -2,14 +2,15 @@
 #
 # Table name: quantification_values
 #
-#  id           :bigint           not null, primary key
-#  location_id  :bigint
-#  label_id     :bigint
-#  year         :integer
-#  first_value  :float
-#  created_at   :datetime         not null
-#  updated_at   :datetime         not null
-#  second_value :float
+#  id            :bigint           not null, primary key
+#  location_id   :bigint
+#  label_id      :bigint
+#  year          :integer
+#  first_value   :float
+#  created_at    :datetime         not null
+#  updated_at    :datetime         not null
+#  second_value  :float
+#  document_slug :string
 #
 require 'rails_helper'
 

--- a/spec/services/import_quantifications_spec.rb
+++ b/spec/services/import_quantifications_spec.rb
@@ -3,10 +3,10 @@ require 'rails_helper'
 # rubocop disable:LineLength
 object_contents = {
   "#{CW_FILES_PREFIX}quantifications/CW_NDC_quantification_commas.csv" => <<~END_OF_CSV,
-    ISO,Country,Year,Value,Range,Label
-    AFG,Afghanistan,2025,40.3,No,2025 High pledge
-    AFG,Afghanistan,2030,48.93954,No,2030 Low pledge
-    AGO,Angola,2025,113.28797,No,2025 High pledge
+    ISO,Document,Country,Year,Value,Range,Label
+    AFG,First NDC,Afghanistan,2025,40.3,No,2025 High pledge
+    AFG,First NDC,Afghanistan,2030,48.93954,No,2030 Low pledge
+    AGO,First NDC,Angola,2025,113.28797,No,2025 High pledge
   END_OF_CSV
 }
 # rubocop enable:LineLength


### PR DESCRIPTION
Add `latest` flag and `document_slug` to `GET /api/v1/quantifications` endpoint. 

With the new data, this endpoint will return all targets from all NDC documents. The latest flag is to mark which one is coming from the latest NDC submission document.

The new data is currently only on `development` prefix. To test it, change prefix to `CW_FILES_PREFIX=climatewatch.org/development/climate-watch/` and run `bin/rails quantifications:import`

![image](https://user-images.githubusercontent.com/1286444/170989942-7efe1007-0547-40e9-9039-ae180cded574.png)
