### PR TITLE
Feature/country ghg previous targets

### DIFF
--- a/app/javascript/app/components/country/country-ghg-emissions/country-ghg-emissions-actions.js
+++ b/app/javascript/app/components/country/country-ghg-emissions/country-ghg-emissions-actions.js
@@ -22,26 +22,19 @@ const fetchCountryGhgEmissionsData = createThunkAction(
         if (response.ok) return response.json();
         throw Error(response.statusText);
       }),
-      fetch(
-        `/api/v1/quantifications?location=${filters.location}`
-      ).then(response => {
-        if (response.ok) return response.json();
-        throw Error(response.statusText);
-      })
+      fetch(`/api/v1/quantifications?location=${filters.location}`).then(
+        response => {
+          if (response.ok) return response.json();
+          throw Error(response.statusText);
+        }
+      )
     ];
 
     Promise.all(promises)
       .then(data => {
         let quantifications;
         if (data[1].length) {
-          quantifications = sortBy(
-            data[1].map(quantification => ({
-              value: quantification.value,
-              label: quantification.label,
-              year: quantification.year
-            })),
-            'year'
-          );
+          quantifications = sortBy(data[1], 'year');
         }
         dispatch(
           fetchCountryGhgEmissionsDataReady({ data: data[0], quantifications })

--- a/app/javascript/app/components/country/country-ghg-emissions/country-ghg-emissions-component.jsx
+++ b/app/javascript/app/components/country/country-ghg-emissions/country-ghg-emissions-component.jsx
@@ -1,8 +1,9 @@
-import React, { PureComponent } from 'react';
+import React, { useState } from 'react';
 import PropTypes from 'prop-types';
 import cx from 'classnames';
 import Dropdown from 'components/dropdown';
 import ButtonGroup from 'components/button-group';
+import CheckInput from 'components/check-input';
 import Tag from 'components/tag';
 import { CALCULATION_OPTIONS } from 'app/data/constants';
 import Chart from 'components/charts/chart';
@@ -15,79 +16,97 @@ import DataZoom from 'components/data-zoom';
 import quantificationTagTheme from 'styles/themes/tag/quantification-tag.scss';
 import styles from './country-ghg-emissions-styles.scss';
 
-class CountryGhgEmissions extends PureComponent {
-  renderFilterDropdowns() {
-    const {
-      sources,
-      calculations,
-      handleSourceChange,
-      handleCalculationChange,
-      calculationSelected,
-      sourceSelected
-    } = this.props;
-    return [
-      <Dropdown
-        key="filter1"
-        label="Data Source"
-        options={sources}
-        onValueChange={handleSourceChange}
-        value={sourceSelected}
-        hideResetButton
-      />,
-      <Dropdown
-        key="filter2"
-        label="Metric"
-        options={calculations}
-        onValueChange={handleCalculationChange}
-        value={calculationSelected}
-        hideResetButton
-      />
+const FEATURE_COUNTRY_CHANGES = process.env.FEATURE_COUNTRY_CHANGES === 'true';
+
+const CountryGhgEmissions = props => {
+  const {
+    data,
+    domain,
+    quantifications,
+    loading,
+    config,
+    handleYearHover,
+    filtersOptions,
+    filtersSelected,
+    dataZoomData,
+    dataZoomPosition,
+    setDataZoomPosition,
+    setYears,
+    dataZoomYears,
+    sources,
+    calculations,
+    handleSourceChange,
+    handleCalculationChange,
+    calculationSelected,
+    sourceSelected,
+    iso,
+    handleInfoClick,
+    handlePngDownloadModal,
+    isEmbed,
+    downloadLink,
+    quantificationsTagsConfig,
+    countryName,
+    pngSelectionSubtitle,
+    pngDownloadId
+  } = props;
+
+  const [previousTargetsChecked, setPreviousTargetsChecked] = useState(false);
+
+  const renderFilterDropdowns = () => [
+    <Dropdown
+      key="filter1"
+      label="Data Source"
+      options={sources}
+      onValueChange={handleSourceChange}
+      value={sourceSelected}
+      hideResetButton
+    />,
+    <Dropdown
+      key="filter2"
+      label="Metric"
+      options={calculations}
+      onValueChange={handleCalculationChange}
+      value={calculationSelected}
+      hideResetButton
+    />
+  ];
+
+  const renderActionButtons = () => {
+    const notEmbedButtonGroupConfig = [
+      {
+        type: 'info',
+        onClick: handleInfoClick,
+        dataTour: 'countries-06'
+      },
+      {
+        type: 'share',
+        shareUrl: `/embed/countries/${iso}/ghg-emissions`,
+        analyticsGraphName: 'Country/Ghg-emissions',
+        positionRight: true,
+        dataTour: 'countries-05'
+      },
+      {
+        type: 'downloadCombo',
+        dataTour: 'countries-04',
+        options: [
+          {
+            label: 'Save as image (PNG)',
+            action: handlePngDownloadModal
+          },
+          {
+            label: 'Go to data explorer',
+            link: downloadLink,
+            target: '_self'
+          }
+        ]
+      },
+      {
+        type: 'addToUser'
+      }
     ];
-  }
-
-  renderActionButtons() {
-    const {
-      iso,
-      handleInfoClick,
-      handlePngDownloadModal,
-      isEmbed,
-      downloadLink
-    } = this.props;
-
     const buttonGroupConfig = isEmbed
       ? [{ type: 'info', onClick: handleInfoClick }]
-      : [
-        {
-          type: 'info',
-          onClick: handleInfoClick,
-          dataTour: 'countries-06'
-        },
-        {
-          type: 'share',
-          shareUrl: `/embed/countries/${iso}/ghg-emissions`,
-          analyticsGraphName: 'Country/Ghg-emissions',
-          positionRight: true,
-          dataTour: 'countries-05'
-        },
-        {
-          type: 'downloadCombo',
-          dataTour: 'countries-04',
-          options: [
-            {
-              label: 'Save as image (PNG)',
-              action: handlePngDownloadModal
-            },
-            {
-              label: 'Go to data explorer',
-              link: downloadLink,
-              target: '_self'
-            }
-          ]
-        },
-        {
-          type: 'addToUser'
-        }
-      ];
+      : notEmbedButtonGroupConfig;
 
     const buttons = [
       <ButtonGroup
@@ -97,27 +116,9 @@ class CountryGhgEmissions extends PureComponent {
       />
     ];
     return buttons;
-  }
+  };
 
-  renderChart() {
-    const {
-      calculationSelected,
-      data,
-      domain,
-      quantifications,
-      loading,
-      config,
-      handleYearHover,
-      filtersOptions,
-      filtersSelected,
-      sourceSelected,
-      dataZoomData,
-      dataZoomPosition,
-      setDataZoomPosition,
-      setYears,
-      dataZoomYears
-    } = this.props;
-
+  const renderChart = () => {
     const points = !isPageContained ? quantifications : [];
     const useLineChart =
       calculationSelected.value === CALCULATION_OPTIONS.PER_CAPITA.value ||
@@ -156,74 +157,79 @@ class CountryGhgEmissions extends PureComponent {
         }
       />
     );
-  }
+  };
 
-  renderQuantificationsTags() {
-    const { loading, quantificationsTagsConfig } = this.props;
-    return (
-      <ul>
-        {!loading &&
-          !isPageContained &&
-          quantificationsTagsConfig.map(q => (
-            <Tag
-              theme={quantificationTagTheme}
-              key={q.label}
-              canRemove={false}
-              label={q.label}
-              color={q.color}
-              data={q}
-              className={styles.quantificationsTags}
-            />
-          ))}
-      </ul>
-    );
-  }
+  const renderQuantificationsTags = () => (
+    <ul>
+      {!loading &&
+        !isPageContained &&
+        quantificationsTagsConfig.map(q => (
+          <Tag
+            theme={quantificationTagTheme}
+            key={q.label}
+            canRemove={false}
+            label={q.label}
+            color={q.color}
+            data={q}
+            className={styles.quantificationsTags}
+          />
+        ))}
+    </ul>
+  );
 
-  render() {
-    const {
-      isEmbed,
-      countryName,
-      pngSelectionSubtitle,
-      pngDownloadId
-    } = this.props;
-    return (
-      <div className={styles.container}>
-        <EmissionsMetaProvider />
-        <WbCountryDataProvider />
-        <TabletLandscape>
-          <div
-            className={cx(styles.graphControls, {
-              [styles.graphControlsEmbed]: isEmbed
-            })}
-          >
-            {this.renderFilterDropdowns()}
-            {this.renderActionButtons()}
-          </div>
-          {this.renderChart()}
-          {this.renderQuantificationsTags()}
-        </TabletLandscape>
-        <TabletPortraitOnly>
-          <div className={styles.graphControlsSection}>
-            {this.renderFilterDropdowns()}
-          </div>
-          {this.renderChart()}
-          {this.renderQuantificationsTags()}
-          <div className={styles.graphControlsSection}>
-            {this.renderActionButtons()}
-          </div>
-        </TabletPortraitOnly>
-        <ModalPngDownload
-          id={pngDownloadId}
-          title={`GHG Emissions and Emissions Targets in ${countryName}`}
-          selectionSubtitle={pngSelectionSubtitle}
+  const renderTargetsToggle = () => (
+    <div className={styles.targetsToggle}>
+      <CheckInput
+        id="toggle-targets"
+        className={styles.checkbox}
+        checked={previousTargetsChecked}
+        label="Show previous targets"
+        onChange={() => setPreviousTargetsChecked(!previousTargetsChecked)}
+        toggleFirst
+      />
+    </div>
+  );
+
+  return (
+    <div className={styles.container}>
+      <EmissionsMetaProvider />
+      <WbCountryDataProvider />
+      <TabletLandscape>
+        <div
+          className={cx(styles.graphControls, {
+            [styles.graphControlsEmbed]: isEmbed
+          })}
         >
-          {this.renderChart()}
-          {this.renderQuantificationsTags()}
-        </ModalPngDownload>
-      </div>
-    );
-  }
-}
+          {renderFilterDropdowns()}
+          {renderActionButtons()}
+          {FEATURE_COUNTRY_CHANGES && renderTargetsToggle()}
+        </div>
+        {renderChart()}
+        {renderQuantificationsTags()}
+      </TabletLandscape>
+      <TabletPortraitOnly>
+        <div className={styles.graphControlsSection}>
+          {renderFilterDropdowns()}
+        </div>
+        {renderChart()}
+        {renderQuantificationsTags()}
+        <div className={styles.graphControlsSection}>
+          {renderActionButtons()}
+          {FEATURE_COUNTRY_CHANGES && renderTargetsToggle()}
+        </div>
+      </TabletPortraitOnly>
+      <ModalPngDownload
+        id={pngDownloadId}
+        title={`GHG Emissions and Emissions Targets in ${countryName}`}
+        selectionSubtitle={pngSelectionSubtitle}
+      >
+        {renderChart()}
+        {renderQuantificationsTags()}
+        {FEATURE_COUNTRY_CHANGES && renderTargetsToggle()}
+      </ModalPngDownload>
+    </div>
+  );
+};
 
 CountryGhgEmissions.propTypes = {
   isEmbed: PropTypes.bool,

--- a/app/javascript/app/components/country/country-ghg-emissions/country-ghg-emissions-component.jsx
+++ b/app/javascript/app/components/country/country-ghg-emissions/country-ghg-emissions-component.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React from 'react';
 import PropTypes from 'prop-types';
 import cx from 'classnames';
 import Dropdown from 'components/dropdown';
@@ -37,6 +37,8 @@ const CountryGhgEmissions = props => {
     calculations,
     handleSourceChange,
     handleCalculationChange,
+    handleShowPreviousTargets,
+    showPreviousTargets,
     calculationSelected,
     sourceSelected,
     iso,
@@ -49,8 +51,6 @@ const CountryGhgEmissions = props => {
     pngSelectionSubtitle,
     pngDownloadId
   } = props;
-
-  const [previousTargetsChecked, setPreviousTargetsChecked] = useState(false);
 
   const renderFilterDropdowns = () => [
     <Dropdown
@@ -182,9 +182,9 @@ const CountryGhgEmissions = props => {
       <CheckInput
         id="toggle-targets"
         className={styles.checkbox}
-        checked={previousTargetsChecked}
+        checked={showPreviousTargets}
         label="Show previous targets"
-        onChange={() => setPreviousTargetsChecked(!previousTargetsChecked)}
+        onChange={() => handleShowPreviousTargets(!showPreviousTargets)}
         toggleFirst
       />
     </div>
@@ -252,6 +252,8 @@ CountryGhgEmissions.propTypes = {
   handleYearHover: PropTypes.func,
   handlePngDownloadModal: PropTypes.func,
   handleSourceChange: PropTypes.func.isRequired,
+  handleShowPreviousTargets: PropTypes.func.isRequired,
+  showPreviousTargets: PropTypes.bool,
   handleCalculationChange: PropTypes.func.isRequired,
   pngSelectionSubtitle: PropTypes.string,
   downloadLink: PropTypes.string,

--- a/app/javascript/app/components/country/country-ghg-emissions/country-ghg-emissions-styles.scss
+++ b/app/javascript/app/components/country/country-ghg-emissions/country-ghg-emissions-styles.scss
@@ -84,3 +84,9 @@
     margin-top: -140px;
   }
 }
+
+.targetsToggle {
+  display: flex;
+  align-items: center;
+  margin-top: 24px;
+}

--- a/app/javascript/app/components/country/country-ghg-emissions/country-ghg-emissions.js
+++ b/app/javascript/app/components/country/country-ghg-emissions/country-ghg-emissions.js
@@ -27,14 +27,15 @@ import {
   getChartDomain,
   getChartConfig,
   getSelectorDefaults,
-  getQuantificationsData,
   getQuantificationsTagsConfig,
   getFilterOptions,
   getFiltersSelected,
   getDownloadLink,
   getPngSelectionSubtitle,
   getDataZoomYears,
-  getDataZoomData
+  getDataZoomData,
+  getQuantificationsData,
+  getShowPreviousTargets
 } from './country-ghg-emissions-selectors';
 
 const actions = { ...ownActions, ...modalActions, ...pngModalActions };
@@ -77,7 +78,8 @@ const mapStateToProps = (state, { location, match }) => {
     selectorDefaults: getSelectorDefaults(countryGhg),
     downloadLink: getDownloadLink(countryGhg),
     dataZoomYears: getDataZoomYears(countryGhg),
-    dataZoomData: getDataZoomData(countryGhg)
+    dataZoomData: getDataZoomData(countryGhg),
+    showPreviousTargets: getShowPreviousTargets(countryGhg)
   };
 };
 
@@ -124,6 +126,13 @@ function CountryGhgEmissionsContainer(props) {
         value: max
       }
     ]);
+  };
+
+  const handleShowPreviousTargets = showPreviousTargets => {
+    updateUrlParam({
+      name: 'show_previous_targets',
+      value: showPreviousTargets
+    });
   };
 
   const [updatedData, setUpdatedData] = useState(data);
@@ -235,6 +244,7 @@ function CountryGhgEmissionsContainer(props) {
     pngDownloadId,
     handleSourceChange,
     handleCalculationChange,
+    handleShowPreviousTargets,
     handleInfoClick,
     handleAnalyticsClick,
     handlePngDownloadModal,


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/9701591/175555541-27a9d288-cbcb-4ea1-9978-65ce50915f98.png)
This PR adds the Show previous targets switch on the GHG emissions section of the country page. 
When active the chart shows all "quantifications" / targets. When deactivated only shows the last and the lts ones.