### PR TITLE
fixes metadata for several sections

### DIFF
--- a/app/javascript/app/components/country/country-climate-vulnerability/country-climate-vulnerability.js
+++ b/app/javascript/app/components/country/country-climate-vulnerability/country-climate-vulnerability.js
@@ -4,13 +4,11 @@ import { connect } from 'react-redux';
 import { CLIMATE_VULNERABILITY_DEFINITIONS } from 'data/constants';
 import { actions } from 'components/modal-metadata';
 import Component from './country-climate-vulnerability-component';
-import { handleInfoMetadataClick } from '../country-utils';
 import {
   getSectionData,
   getQueryIsos,
   getCountryName,
-  getMaximumCountries,
-  getCountryIndicators
+  getMaximumCountries
 } from './country-climate-vulnerability-selectors';
 
 const mapStateToProps = (state, { match, location }) => {
@@ -32,7 +30,6 @@ const mapStateToProps = (state, { match, location }) => {
     countries: getQueryIsos(search),
     maximumCountries: getMaximumCountries(climateVulnerability),
     countryName: getCountryName(climateVulnerability),
-    indicators: getCountryIndicators(climateVulnerability),
     ready: adaptations.loaded,
     definitions,
     iso
@@ -40,14 +37,16 @@ const mapStateToProps = (state, { match, location }) => {
 };
 
 const CountryClimateVulnerability = props => {
-  const { setModalMetadata, indicators } = props;
-  const handleInfoClick = slug =>
-    handleInfoMetadataClick(
-      slug,
-      'Emission drivers',
-      indicators,
-      setModalMetadata
-    );
+  const { setModalMetadata } = props;
+
+  const handleInfoClick = slug => {
+    setModalMetadata({
+      category: 'Climate Vulnerability and Readiness',
+      slugs: slug,
+      open: true
+    });
+  };
+
   return createElement(Component, { ...props, handleInfoClick });
 };
 

--- a/app/javascript/app/components/country/country-emission-drivers/country-emission-drivers.js
+++ b/app/javascript/app/components/country/country-emission-drivers/country-emission-drivers.js
@@ -2,15 +2,13 @@ import { createElement } from 'react';
 import { withRouter } from 'react-router-dom';
 import { connect } from 'react-redux';
 import { actions } from 'components/modal-metadata';
-import { handleInfoMetadataClick } from '../country-utils';
 import Component from './country-emission-drivers-component';
 
 import {
   getSectionData,
   getQueryIsos,
   getCountryName,
-  getMaximumCountries,
-  getCountryIndicators
+  getMaximumCountries
 } from './country-emission-drivers-selectors';
 
 const mapStateToProps = (state, { match, location }) => {
@@ -26,7 +24,6 @@ const mapStateToProps = (state, { match, location }) => {
 
   return {
     sectionData: getSectionData(climateVulnerability),
-    indicators: getCountryIndicators(climateVulnerability),
     countries: getQueryIsos(search),
     maximumCountries: getMaximumCountries(climateVulnerability),
     countryName: getCountryName(climateVulnerability),
@@ -35,15 +32,15 @@ const mapStateToProps = (state, { match, location }) => {
 };
 
 const EmissionDrivers = props => {
-  const { setModalMetadata, indicators } = props;
+  const { setModalMetadata } = props;
 
-  const handleInfoClick = slug =>
-    handleInfoMetadataClick(
-      slug,
-      'Emission drivers',
-      indicators,
-      setModalMetadata
-    );
+  const handleInfoClick = slug => {
+    setModalMetadata({
+      category: 'Emission drivers',
+      slugs: slug,
+      open: true
+    });
+  };
 
   return createElement(Component, {
     ...props,

--- a/app/javascript/app/components/country/country-subnational-actions/country-subnational-actions.js
+++ b/app/javascript/app/components/country/country-subnational-actions/country-subnational-actions.js
@@ -19,10 +19,11 @@ const mapStateToProps = (state, { match }) => {
 
 const SubnationalActions = props => {
   const { setModalMetadata } = props;
+
   const handleInfoClick = slug => {
     setModalMetadata({
-      category: 'Country',
-      slug,
+      category: 'Subnational Climate Actions',
+      slugs: slug,
       open: true
     });
   };


### PR DESCRIPTION
Fixes info buttons for the following sections:
- What are important sectoral trends in `countryName`?
- What is `countryName` vulnerability and readiness situation?
- What are `countryName`  subnational climate actions?

In those sections, the metadata was getting via `http://localhost:3000/api/v1/country_profile/indicators` endpoint. This has been changed to retrieve the metadata data from `https://staging.climatewatchdata.org/api/v1/metadata`

For these specific charts:
![image](https://user-images.githubusercontent.com/999124/177147644-a6f42fa4-f37d-42eb-9075-446eea5c262a.png)

Their metadata source, `CAT`, is not found in `https://staging.climatewatchdata.org/api/v1/metadata` endpoint.