### PR TITLE
refactoring: Resize background images returned by WRI Stories

### DIFF
--- a/app/models/story.rb
+++ b/app/models/story.rb
@@ -13,6 +13,8 @@
 #  tags                 :string           default([]), is an Array
 #
 class Story < ApplicationRecord
+  WRI_IMAGE_PREFIX = "https://files.wri.org/d8/s3fs-public/".freeze
+
   def self.stories_filter(tags, limit)
     tags_array = tags.try(:split, ',')
     limit = limit.try(:to_i) || 5
@@ -39,5 +41,12 @@ class Story < ApplicationRecord
     Story.where('(NOT tags && ARRAY[?]::varchar[]) OR tags IS NULL', tags).
       order(published_at: :desc).
       limit(limit)
+  end
+
+  def resized_background_image_url(size: "500x300")
+    index = background_image_url.index(WRI_IMAGE_PREFIX)
+    return background_image_url unless index
+
+    background_image_url.dup.insert(index + WRI_IMAGE_PREFIX.length, "styles/#{size}/s3/")
   end
 end

--- a/app/serializers/api/v1/story_serializer.rb
+++ b/app/serializers/api/v1/story_serializer.rb
@@ -6,6 +6,10 @@ module Api
       attribute :background_image_url
       attribute :tags
       attribute :published_at
+
+      def background_image_url
+        object.resized_background_image_url
+      end
     end
   end
 end

--- a/spec/controllers/api/v1/stories_controller_spec.rb
+++ b/spec/controllers/api/v1/stories_controller_spec.rb
@@ -2,9 +2,10 @@ require 'rails_helper'
 
 describe Api::V1::StoriesController, type: :controller do
   context do
-    let!(:some_stories) {
-      FactoryBot.create_list(:story, 7)
-    }
+    let!(:some_stories) { FactoryBot.create_list(:story, 7) }
+    let!(:story_with_wri_background_image) do
+      create :story, background_image_url: 'https://files.wri.org/d8/s3fs-public/2023-03/ipcc-flooding_0.jpg'
+    end
 
     describe 'GET index' do
       it 'returns a successful 200 response' do
@@ -16,6 +17,13 @@ describe Api::V1::StoriesController, type: :controller do
         get :index, params: {limit: 6}
         parsed_body = JSON.parse(response.body)
         expect(parsed_body.length).to eq(6)
+      end
+
+      it 'returns resized background image url for WRI images' do
+        get :index
+        parsed_body = JSON.parse response.body
+        response = parsed_body.find { |story| story['title'] == story_with_wri_background_image.title }
+        expect(response['background_image_url']).to include('https://files.wri.org/d8/s3fs-public/styles/500x300/s3/2023-03/ipcc-flooding_0.jpg')
       end
     end
   end

--- a/spec/models/story_spec.rb
+++ b/spec/models/story_spec.rb
@@ -50,4 +50,22 @@ RSpec.describe Story, type: :model do
       expect(Story.stories_filter('NDC, esp, climate watch', 5)).to have(5).items
     end
   end
+
+  describe '#resized_background_image_url' do
+    context 'when background image comes from WRI' do
+      let(:story) { FactoryBot.create(:story, background_image_url: 'https://files.wri.org/d8/s3fs-public/2023-03/ipcc-flooding_0.jpg') }
+
+      it 'should return resized background image url' do
+        expect(story.resized_background_image_url).to include('https://files.wri.org/d8/s3fs-public/styles/500x300/s3/2023-03/ipcc-flooding_0.jpg')
+      end
+    end
+
+    context 'when background image does not come from WRI' do
+      let(:story) { FactoryBot.create(:story, background_image_url: 'https://www.google.com/images/branding/googlelogo/2x/googlelogo_color_272x92dp.png') }
+
+      it 'should return resized background image url' do
+        expect(story.resized_background_image_url).to eq('https://www.google.com/images/branding/googlelogo/2x/googlelogo_color_272x92dp.png')
+      end
+    end
+  end
 end


### PR DESCRIPTION
Modifying url of WRI background images used for Stories. It seems that S3 bucket contains data in `500x300` which are a lot smaller so API will return modified url instead of original one and use these smaller data.

https://basecamp.com/1756858/projects/13795275/todos/480218929