### PR TITLE
Add iso code columns to the GHG Emissions module's data downloads

### DIFF
--- a/app/javascript/app/components/ghg-emissions/ghg-emissions-component.jsx
+++ b/app/javascript/app/components/ghg-emissions/ghg-emissions-component.jsx
@@ -317,7 +317,11 @@ function GhgEmissions(props) {
             <Table
               data={tableData}
               horizontalScroll
-              firstColumnHeaders={[GHG_TABLE_HEADER[fieldToBreakBy], 'unit']}
+              firstColumnHeaders={[
+                'iso',
+                GHG_TABLE_HEADER[fieldToBreakBy],
+                'unit'
+              ]}
               flexGrow={0}
               headerHeight={30}
               parseHtml

--- a/app/javascript/app/components/ghg-emissions/ghg-emissions-component.jsx
+++ b/app/javascript/app/components/ghg-emissions/ghg-emissions-component.jsx
@@ -330,6 +330,7 @@ function GhgEmissions(props) {
               splittedColumns
               titleLinks={titleLinks}
               theme={ghgTableTheme}
+              hiddenColumns={['iso']}
             />
           </span>
         )}

--- a/app/javascript/app/components/ghg-emissions/ghg-emissions-component.jsx
+++ b/app/javascript/app/components/ghg-emissions/ghg-emissions-component.jsx
@@ -317,11 +317,7 @@ function GhgEmissions(props) {
             <Table
               data={tableData}
               horizontalScroll
-              firstColumnHeaders={[
-                'iso',
-                GHG_TABLE_HEADER[fieldToBreakBy],
-                'unit'
-              ]}
+              firstColumnHeaders={[GHG_TABLE_HEADER[fieldToBreakBy], 'unit']}
               flexGrow={0}
               headerHeight={30}
               parseHtml

--- a/app/javascript/app/components/ghg-emissions/ghg-emissions-selectors/ghg-emissions-selectors-table-data.js
+++ b/app/javascript/app/components/ghg-emissions/ghg-emissions-selectors/ghg-emissions-selectors-table-data.js
@@ -52,6 +52,8 @@ export const getTableData = createSelector(
       return { [String(d.x)]: formatValue(d[c.value]) }; // year: value
     };
     return yColumnOptions.map(c => ({
+      // Conditionally add ISO to the data when countries or regions is selected
+      ...(model === 'regions' && { iso: c.iso }),
       [GHG_TABLE_HEADER[model]]: c.label,
       unit,
       ...data.reduce(

--- a/app/javascript/app/components/ghg-emissions/ghg-emissions.js
+++ b/app/javascript/app/components/ghg-emissions/ghg-emissions.js
@@ -220,7 +220,11 @@ function GhgEmissionsContainer(props) {
   };
 
   const createCSVContent = () => {
-    const defaultColumnOrder = [GHG_TABLE_HEADER[fieldToBreakBy], 'unit'];
+    const defaultColumnOrder = [
+      'iso',
+      GHG_TABLE_HEADER[fieldToBreakBy],
+      'unit'
+    ];
     const stripHtmlFromUnit = d => ({ ...d, unit: stripHTML(d.unit) });
     const parsedTableData = tableData.map(stripHtmlFromUnit);
     const encodeParam = param =>

--- a/app/javascript/app/components/table/table-component.jsx
+++ b/app/javascript/app/components/table/table-component.jsx
@@ -21,6 +21,7 @@ function TableComponent(props) {
     data,
     hasColumnSelect,
     activeColumns,
+    hiddenColumns = [],
     columnsOptions,
     handleColumnChange,
     setRowsHeight,
@@ -58,7 +59,9 @@ function TableComponent(props) {
 
   if (!data || !data.length) return null;
   const hasColumnSelectedOptions = hasColumnSelect && columnsOptions;
-  const activeColumnNames = activeColumns.map(c => c.value);
+  const activeColumnNames = activeColumns
+    .map(c => c.value)
+    .filter(c => !hiddenColumns.includes(c));
   const firstColumns =
     firstColumnHeaders.filter(c => activeColumnNames.includes(c)) || [];
   const columnData = firstColumns.concat(
@@ -182,7 +185,7 @@ function TableComponent(props) {
       >
         <AutoSizer disableHeight>
           {({ width }) =>
-            (splittedColumns ? (
+            splittedColumns ? (
               <ScrollSync>
                 {({ onScroll, scrollTop }) => (
                   <div className={styles.scrollTable}>
@@ -206,7 +209,7 @@ function TableComponent(props) {
                 position: 'full',
                 width
               })
-            ))
+            )
           }
         </AutoSizer>
       </div>
@@ -220,6 +223,7 @@ TableComponent.propTypes = {
   hasColumnSelect: PropTypes.bool,
   flexGrow: PropTypes.number,
   activeColumns: PropTypes.array,
+  hiddenColumns: PropTypes.array,
   columnsOptions: PropTypes.array,
   handleColumnChange: PropTypes.func,
   setRowsHeight: PropTypes.func.isRequired,


### PR DESCRIPTION
This PR is the frontend counterpart to adding an ISO code column to data downloads. 

While the _Data Explorer_'s CSV downloads come from our API (with the exception of _Pathways_, which is downloaded from a third party API), the _GHG Emissions_ CSV is generated by the frontend, based on the data passed onto the table. 

## Implementation choices

Because the data displayed and the data downloaded won't necessarily be the same anymore, I see two options:  

1. Add a `getDownloadData` selector
    - the existing `getTableData` could make use of it and simply remove the `iso` in order to parse the data for the table
      _I feel this would be confusing for future development as it would deviate from the implementation in other modules_
2. Add the `iso` to the existing `getTableData` selector  
    - and add a mechanism/prop in the general `table` component to allow us to hide the new column

In this PR I opted for the second option because: 
  - it requires the least amount of code changes; less probability of introducing bugs  
  - it keeps the selectors' implementation consistent with other modules  
    _`getData`_ returns chart data, `getTableData` returns table data, CSV downloads are still based on the latter
  - we get a new _reusable_ mechanism to use in other modules in which the tabular data displayed may not be consistent with the downloadable data (and the latter is generated in the frontend)  

## Caveats

I'm not exactly the biggest fan of [conditionally adding the iso to the data based on the model](https://github.com/ClimateWatch-Vizzuality/climate-watch/compare/add-iso-code-columns?expand=1#diff-3e97ed64d09e7a7933dda783fbe67e5ca6fd5922ddd0d887d8d65672a1aa6817R56) in this way (done because we'll only need the iso when the user has chosen to show the data by either countries or regions, but not sectors or gas) nor specifying the columns in [this way](https://github.com/ClimateWatch-Vizzuality/climate-watch/pull/1668/files#diff-bd321acecca25365c78d512bba4766e05491742e458181ae7eae0f9290f38746R223-R227) .

I've pondered a similar implementation to the one in the [data explorer](https://github.com/ClimateWatch-Vizzuality/climate-watch/blob/develop/app/javascript/app/data/data-explorer-constants.js#L16), but it feels like it would be bug prone due to the usage of `GHG_TABLE_HEADER` in places such as [here](https://github.com/ClimateWatch-Vizzuality/climate-watch/blob/develop/app/javascript/app/components/ghg-emissions/ghg-emissions-selectors/ghg-emissions-selectors-table-data.js#L85). Worth considering in the future, but perhaps not now due to limitations. 

## How to test  
- Visit: http://localhost:3000/ghg-emissions
- Ensure that, when the user clicks the _"Download current data button"_: 
  - When the user has selected to show data by _"Countries"_ or _"Regions"_
    - The resulting CSV includes the ISO code  
  - When the user has selected to show data by _"Sectors"_ or _"Gases"_  
    - The resulting CSV does *not* include the ISO code  
  - The table itself (columns in particular) remain unchanged