### PR TITLE
Fix visualizing individual EU members on NDCS/LTS/Net-Zero explorers

### DIFF
--- a/app/javascript/app/components/ndcs/lts-explore-map/lts-explore-map-selectors.js
+++ b/app/javascript/app/components/ndcs/lts-explore-map/lts-explore-map-selectors.js
@@ -20,6 +20,7 @@ import { TOP_EMITTERS_OPTION } from 'data/constants';
 import {
   selectedLocationsFunction,
   selectedCountriesISOFunction,
+  selectedMapCountriesISOFunction,
   selectedCountriesFunction,
   categoryIndicatorsFunction,
   pathsWithStylesFunction,
@@ -135,6 +136,11 @@ const getisDefaultLocationSelected = createSelector(
 export const getSelectedCountriesISO = createSelector(
   [getSelectedCountries],
   selectedCountriesISOFunction
+);
+
+export const getSelectedMapCountriesISO = createSelector(
+  [getIsShowEUCountriesChecked, getSelectedCountriesISO],
+  selectedMapCountriesISOFunction
 );
 
 export const getCategories = createSelector(getCategoriesData, categories =>

--- a/app/javascript/app/components/ndcs/lts-explore-table/lts-explore-table-selectors.js
+++ b/app/javascript/app/components/ndcs/lts-explore-table/lts-explore-table-selectors.js
@@ -6,7 +6,7 @@ import isEmpty from 'lodash/isEmpty';
 import { replaceStringAbbr } from 'components/abbr-replace';
 import {
   getMapIndicator,
-  getSelectedCountriesISO
+  getSelectedMapCountriesISO
 } from 'components/ndcs/lts-explore-map/lts-explore-map-selectors';
 
 const getCountries = state => state.countries || null;
@@ -35,8 +35,8 @@ export const getIndicatorsParsed = createSelector(
 );
 
 export const tableGetSelectedData = createSelector(
-  [getIndicatorsParsed, getCountries, getSelectedCountriesISO],
-  (indicators, countries, selectedCountriesISO) => {
+  [getIndicatorsParsed, getCountries, getSelectedMapCountriesISO],
+  (indicators, countries, selectedMapCountriesISO) => {
     if (!indicators || !indicators.length || !indicators[0].locations) {
       return [];
     }
@@ -45,7 +45,7 @@ export const tableGetSelectedData = createSelector(
 
     return Object.keys(refIndicator.locations)
       .map(iso => {
-        if (!selectedCountriesISO.includes(iso)) return null;
+        if (!selectedMapCountriesISO.includes(iso)) return null;
         const countryData =
           countries.find(country => country.iso_code3 === iso) || {};
         const row = {

--- a/app/javascript/app/components/ndcs/ndcs-explore-map/ndcs-explore-map-selectors.js
+++ b/app/javascript/app/components/ndcs/ndcs-explore-map/ndcs-explore-map-selectors.js
@@ -35,6 +35,7 @@ import { getSubmitted2020Isos } from 'utils/indicatorCalculations';
 import {
   selectedLocationsFunction,
   selectedCountriesISOFunction,
+  selectedMapCountriesISOFunction,
   selectedCountriesFunction,
   categoryIndicatorsFunction,
   pathsWithStylesFunction,
@@ -225,6 +226,11 @@ const getisDefaultLocationSelected = createSelector(
 export const getSelectedCountriesISO = createSelector(
   [getSelectedCountries],
   selectedCountriesISOFunction
+);
+
+export const getSelectedMapCountriesISO = createSelector(
+  [getIsShowEUCountriesChecked, getSelectedCountriesISO],
+  selectedMapCountriesISOFunction
 );
 
 export const getMaximumCountries = createSelector(

--- a/app/javascript/app/components/ndcs/ndcs-explore-table/ndcs-explore-table-selectors.js
+++ b/app/javascript/app/components/ndcs/ndcs-explore-table/ndcs-explore-table-selectors.js
@@ -5,7 +5,7 @@ import { filterQuery } from 'app/utils';
 import { replaceStringAbbr } from 'components/abbr-replace';
 import {
   getMapIndicator,
-  getSelectedCountriesISO
+  getSelectedMapCountriesISO
 } from 'components/ndcs/ndcs-explore-map/ndcs-explore-map-selectors';
 import {
   getIndicatorsParsed,
@@ -51,8 +51,8 @@ export const getDefaultColumns = createSelector(
 );
 
 export const tableGetSelectedData = createSelector(
-  [getIndicatorsParsed, getCountries, getSelectedCountriesISO],
-  (indicators, countries, selectedCountriesISO) => {
+  [getIndicatorsParsed, getCountries, getSelectedMapCountriesISO],
+  (indicators, countries, selectedMapCountriesISO) => {
     if (
       !indicators ||
       !indicators.length ||
@@ -68,7 +68,7 @@ export const tableGetSelectedData = createSelector(
     if (!refIndicator) return null;
     return Object.keys(refIndicator.locations)
       .map(iso => {
-        if (!selectedCountriesISO.includes(iso)) return null;
+        if (!selectedMapCountriesISO.includes(iso)) return null;
         const countryData =
           countries.find(country => country.iso_code3 === iso) || {};
         const row = {

--- a/app/javascript/app/components/ndcs/net-zero-map/net-zero-map-selectors.js
+++ b/app/javascript/app/components/ndcs/net-zero-map/net-zero-map-selectors.js
@@ -21,6 +21,7 @@ import { getIsShowEUCountriesChecked } from 'components/ndcs/shared/explore-map/
 import { NET_ZERO_POSITIVE_LABELS, TOP_EMITTERS_OPTION } from 'data/constants';
 import {
   selectedLocationsFunction,
+  selectedMapCountriesISOFunction,
   selectedCountriesISOFunction,
   selectedCountriesFunction,
   categoryIndicatorsFunction,
@@ -141,6 +142,11 @@ export const getCategories = createSelector(getCategoriesData, categories =>
 export const getSelectedCountriesISO = createSelector(
   [getSelectedCountries],
   selectedCountriesISOFunction
+);
+
+export const getSelectedMapCountriesISO = createSelector(
+  [getIsShowEUCountriesChecked, getSelectedCountriesISO],
+  selectedMapCountriesISOFunction
 );
 
 const getisDefaultLocationSelected = createSelector(

--- a/app/javascript/app/components/ndcs/net-zero-table/net-zero-table-selectors.js
+++ b/app/javascript/app/components/ndcs/net-zero-table/net-zero-table-selectors.js
@@ -4,7 +4,7 @@ import sortBy from 'lodash/sortBy';
 import isEmpty from 'lodash/isEmpty';
 import {
   getMapIndicator,
-  getSelectedCountriesISO
+  getSelectedMapCountriesISO
 } from 'components/ndcs/net-zero-map/net-zero-map-selectors';
 import { replaceStringAbbr } from 'components/abbr-replace';
 
@@ -31,8 +31,8 @@ export const getIndicatorsParsed = createSelector(
 );
 
 export const tableGetSelectedData = createSelector(
-  [getIndicatorsParsed, getCountries, getSelectedCountriesISO],
-  (indicators, countries, selectedCountriesISO) => {
+  [getIndicatorsParsed, getCountries, getSelectedMapCountriesISO],
+  (indicators, countries, selectedMapCountriesISO) => {
     if (!indicators || !indicators.length || !indicators[0].locations) {
       return [];
     }
@@ -42,7 +42,7 @@ export const tableGetSelectedData = createSelector(
 
     return Object.keys(refIndicator.locations)
       .map(iso => {
-        if (!selectedCountriesISO.includes(iso)) return null;
+        if (!selectedMapCountriesISO.includes(iso)) return null;
         const countryData =
           countries.find(country => country.iso_code3 === iso) || {};
         const row = {

--- a/app/javascript/app/components/ndcs/shared/selectors.js
+++ b/app/javascript/app/components/ndcs/shared/selectors.js
@@ -1,5 +1,5 @@
 import uniq from 'lodash/uniq';
-import { europeanCountries } from 'app/data/european-countries';
+import { europeanCountries, europeSlug } from 'app/data/european-countries';
 import {
   NO_DOCUMENT_SUBMITTED_COUNTRIES,
   COUNTRY_STYLES
@@ -129,12 +129,34 @@ export const pathsWithStylesFunction = (
 ) => {
   if (!indicator || !worldPaths) return [];
   const paths = [];
-  const selectedWorldPaths = showEUCountriesChecked
-    ? worldPaths
-    : worldPaths.filter(p => !europeanCountries.includes(p.properties.id));
+
+  const euGroupDisplayed = selectedCountriesISO.includes(europeSlug);
+  const allEuCountriesDisplayed = europeanCountries.every(c =>
+    selectedCountriesISO.includes(c)
+  );
+
+  const removeEuCountriesFromPaths =
+    !showEUCountriesChecked && (euGroupDisplayed || allEuCountriesDisplayed);
+  const selectedWorldPaths = removeEuCountriesFromPaths
+    ? worldPaths.filter(p => !europeanCountries.includes(p.properties.id))
+    : worldPaths;
+
+  let countriesToDisplay = selectedCountriesISO;
+  if (euGroupDisplayed && showEUCountriesChecked) {
+    countriesToDisplay = selectedCountriesISO.filter(iso => iso !== europeSlug);
+    countriesToDisplay.push(...europeanCountries);
+  }
+  if (allEuCountriesDisplayed && !showEUCountriesChecked) {
+    countriesToDisplay = selectedCountriesISO.filter(
+      iso => !europeanCountries.includes(iso)
+    );
+    countriesToDisplay.push(europeSlug);
+  }
+
   selectedWorldPaths.forEach(path => {
     if (shouldShowPath(path, zoom)) {
       const { locations, legendBuckets } = indicator;
+
       if (!locations) {
         paths.push({
           ...path,
@@ -161,7 +183,7 @@ export const pathsWithStylesFunction = (
         }
       };
 
-      if (!selectedCountriesISO.includes(iso)) {
+      if (!countriesToDisplay.includes(iso)) {
         const color = '#e8ecf5';
         style.default.fill = color;
         style.hover.fill = color;

--- a/app/javascript/app/components/ndcs/shared/selectors.js
+++ b/app/javascript/app/components/ndcs/shared/selectors.js
@@ -120,35 +120,56 @@ export const categoryIndicatorsFunction = (indicatorsParsed, category) => {
   return categoryIndicators;
 };
 
+// Get whether the EU countries are selected, checking by the 'EUU' iso code.
+// eg: ['EUU', ...]
 const getIsEUGroupDisplayed = selectedCountriesISO =>
   selectedCountriesISO.includes(europeSlug);
 
+// Get whether all EU countries are selected, checking by all their individual iso codes.
+// eg: ['PRT', 'ESP', ...])
 const getAreAllEuCountriesDisplayed = selectedCountriesISO =>
   europeanCountries.every(c => selectedCountriesISO.includes(c));
 
+// Get whether all EU countries are selected, either by the 'EUU' iso code or
+// all their individual iso codes.
 export const getIsEUDisplayedFunction = selectedCountriesISO =>
   getIsEUGroupDisplayed(selectedCountriesISO) ||
   getAreAllEuCountriesDisplayed(selectedCountriesISO);
 
+// Get wether individual EU countries paths should be removed from the map, based on both
+// the "Visualize individual submissions of EU Members" checkbox and on whether all EU
+// countries are selected.
 const getRemoveEuCountriesFromPaths = (
   showEUCountriesChecked,
   selectedCountriesISO
 ) => !showEUCountriesChecked && getIsEUDisplayedFunction(selectedCountriesISO);
 
+// This function takes the array from selectedCountriesISO as well as the value from the
+// "Visualize individual submissions of EU Members" and creates a new array of iso codes
+// that can be used to correctly highlight the selected countries on the map.
 export const selectedMapCountriesISOFunction = (
   showEUCountriesChecked,
   selectedCountriesISO
 ) => {
+  // EU countries selected as a group ('EUU' iso code)
   const euGroupDisplayed = getIsEUGroupDisplayed(selectedCountriesISO);
+
+  // All EU countries selected by their individual ISO codes
   const allEuCountriesDisplayed = getAreAllEuCountriesDisplayed(
     selectedCountriesISO
   );
 
   let countriesToDisplay = selectedCountriesISO;
+
+  // If the EU countries are displayed as a group and we want to display them individually
+  // on the map, then we remove the 'EUU' iso code and add the countries' individual iso codes.
   if (euGroupDisplayed && showEUCountriesChecked) {
     countriesToDisplay = selectedCountriesISO.filter(iso => iso !== europeSlug);
     countriesToDisplay.push(...europeanCountries);
   }
+
+  // If the EU countries are displayed individually by their iso codes but we would like
+  // to display them as the EU group, we remove their individual iso codes and add the 'EUU' one.
   if (allEuCountriesDisplayed && !showEUCountriesChecked) {
     countriesToDisplay = selectedCountriesISO.filter(
       iso => !europeanCountries.includes(iso)
@@ -159,6 +180,9 @@ export const selectedMapCountriesISOFunction = (
   return countriesToDisplay;
 };
 
+// Based on the indicator, zoom level, the selected countries and the "Visualize individual
+// submissions of EU Members" checkbox, return the paths to the map with the correct countries
+// highlighted.
 export const pathsWithStylesFunction = (
   indicator,
   zoom,

--- a/app/javascript/app/components/ndcs/shared/selectors.js
+++ b/app/javascript/app/components/ndcs/shared/selectors.js
@@ -122,19 +122,19 @@ export const categoryIndicatorsFunction = (indicatorsParsed, category) => {
 
 // Get whether the EU countries are selected, checking by the 'EUU' iso code.
 // eg: ['EUU', ...]
-const getIsEUGroupDisplayed = selectedCountriesISO =>
+const getIsEUGroupSelected = selectedCountriesISO =>
   selectedCountriesISO.includes(europeSlug);
 
 // Get whether all EU countries are selected, checking by all their individual iso codes.
 // eg: ['PRT', 'ESP', ...])
-const getAreAllEuCountriesDisplayed = selectedCountriesISO =>
+const getAreAllEuCountriesSelected = selectedCountriesISO =>
   europeanCountries.every(c => selectedCountriesISO.includes(c));
 
 // Get whether all EU countries are selected, either by the 'EUU' iso code or
 // all their individual iso codes.
-export const getIsEUDisplayedFunction = selectedCountriesISO =>
-  getIsEUGroupDisplayed(selectedCountriesISO) ||
-  getAreAllEuCountriesDisplayed(selectedCountriesISO);
+export const getIsEUSelectedFunction = selectedCountriesISO =>
+  getIsEUGroupSelected(selectedCountriesISO) ||
+  getAreAllEuCountriesSelected(selectedCountriesISO);
 
 // Get wether individual EU countries paths should be removed from the map, based on both
 // the "Visualize individual submissions of EU Members" checkbox and on whether all EU
@@ -142,7 +142,7 @@ export const getIsEUDisplayedFunction = selectedCountriesISO =>
 const getRemoveEuCountriesFromPaths = (
   showEUCountriesChecked,
   selectedCountriesISO
-) => !showEUCountriesChecked && getIsEUDisplayedFunction(selectedCountriesISO);
+) => !showEUCountriesChecked && getIsEUSelectedFunction(selectedCountriesISO);
 
 // This function takes the array from selectedCountriesISO as well as the value from the
 // "Visualize individual submissions of EU Members" and creates a new array of iso codes
@@ -152,10 +152,10 @@ export const selectedMapCountriesISOFunction = (
   selectedCountriesISO
 ) => {
   // EU countries selected as a group ('EUU' iso code)
-  const euGroupDisplayed = getIsEUGroupDisplayed(selectedCountriesISO);
+  const euGroupSelected = getIsEUGroupSelected(selectedCountriesISO);
 
   // All EU countries selected by their individual ISO codes
-  const allEuCountriesDisplayed = getAreAllEuCountriesDisplayed(
+  const allEuCountriesSelected = getAreAllEuCountriesSelected(
     selectedCountriesISO
   );
 
@@ -163,14 +163,14 @@ export const selectedMapCountriesISOFunction = (
 
   // If the EU countries are displayed as a group and we want to display them individually
   // on the map, then we remove the 'EUU' iso code and add the countries' individual iso codes.
-  if (euGroupDisplayed && showEUCountriesChecked) {
+  if (euGroupSelected && showEUCountriesChecked) {
     countriesToDisplay = selectedCountriesISO.filter(iso => iso !== europeSlug);
     countriesToDisplay.push(...europeanCountries);
   }
 
   // If the EU countries are displayed individually by their iso codes but we would like
   // to display them as the EU group, we remove their individual iso codes and add the 'EUU' one.
-  if (allEuCountriesDisplayed && !showEUCountriesChecked) {
+  if (allEuCountriesSelected && !showEUCountriesChecked) {
     countriesToDisplay = selectedCountriesISO.filter(
       iso => !europeanCountries.includes(iso)
     );

--- a/app/javascript/app/components/ndcs/shared/selectors.js
+++ b/app/javascript/app/components/ndcs/shared/selectors.js
@@ -120,26 +120,34 @@ export const categoryIndicatorsFunction = (indicatorsParsed, category) => {
   return categoryIndicators;
 };
 
-export const pathsWithStylesFunction = (
-  indicator,
-  zoom,
+const getEuGroupDisplayed = selectedCountriesISO =>
+  selectedCountriesISO.includes(europeSlug);
+
+const getAllEuCountriesDisplayed = selectedCountriesISO =>
+  europeanCountries.every(c => selectedCountriesISO.includes(c));
+
+const getRemoveEuCountriesFromPaths = (
   showEUCountriesChecked,
-  worldPaths,
   selectedCountriesISO
 ) => {
-  if (!indicator || !worldPaths) return [];
-  const paths = [];
-
-  const euGroupDisplayed = selectedCountriesISO.includes(europeSlug);
-  const allEuCountriesDisplayed = europeanCountries.every(c =>
-    selectedCountriesISO.includes(c)
+  const euGroupDisplayed = getEuGroupDisplayed(selectedCountriesISO);
+  const allEuCountriesDisplayed = getAllEuCountriesDisplayed(
+    selectedCountriesISO
   );
 
-  const removeEuCountriesFromPaths =
-    !showEUCountriesChecked && (euGroupDisplayed || allEuCountriesDisplayed);
-  const selectedWorldPaths = removeEuCountriesFromPaths
-    ? worldPaths.filter(p => !europeanCountries.includes(p.properties.id))
-    : worldPaths;
+  return (
+    !showEUCountriesChecked && (euGroupDisplayed || allEuCountriesDisplayed)
+  );
+};
+
+export const selectedMapCountriesISOFunction = (
+  showEUCountriesChecked,
+  selectedCountriesISO
+) => {
+  const euGroupDisplayed = getEuGroupDisplayed(selectedCountriesISO);
+  const allEuCountriesDisplayed = getAllEuCountriesDisplayed(
+    selectedCountriesISO
+  );
 
   let countriesToDisplay = selectedCountriesISO;
   if (euGroupDisplayed && showEUCountriesChecked) {
@@ -152,6 +160,33 @@ export const pathsWithStylesFunction = (
     );
     countriesToDisplay.push(europeSlug);
   }
+
+  return countriesToDisplay;
+};
+
+export const pathsWithStylesFunction = (
+  indicator,
+  zoom,
+  showEUCountriesChecked,
+  worldPaths,
+  selectedCountriesISO
+) => {
+  if (!indicator || !worldPaths) return [];
+  const paths = [];
+
+  const removeEuCountriesFromPaths = getRemoveEuCountriesFromPaths(
+    showEUCountriesChecked,
+    selectedCountriesISO
+  );
+
+  const countriesToDisplayISO = selectedMapCountriesISOFunction(
+    showEUCountriesChecked,
+    selectedCountriesISO
+  );
+
+  const selectedWorldPaths = removeEuCountriesFromPaths
+    ? worldPaths.filter(p => !europeanCountries.includes(p.properties.id))
+    : worldPaths;
 
   selectedWorldPaths.forEach(path => {
     if (shouldShowPath(path, zoom)) {
@@ -183,7 +218,7 @@ export const pathsWithStylesFunction = (
         }
       };
 
-      if (!countriesToDisplay.includes(iso)) {
+      if (!countriesToDisplayISO.includes(iso)) {
         const color = '#e8ecf5';
         style.default.fill = color;
         style.hover.fill = color;

--- a/app/javascript/app/components/ndcs/shared/selectors.js
+++ b/app/javascript/app/components/ndcs/shared/selectors.js
@@ -120,18 +120,18 @@ export const categoryIndicatorsFunction = (indicatorsParsed, category) => {
   return categoryIndicators;
 };
 
-const getEuGroupDisplayed = selectedCountriesISO =>
+const getIsEUGroupDisplayed = selectedCountriesISO =>
   selectedCountriesISO.includes(europeSlug);
 
-const getAllEuCountriesDisplayed = selectedCountriesISO =>
+const getAreAllEuCountriesDisplayed = selectedCountriesISO =>
   europeanCountries.every(c => selectedCountriesISO.includes(c));
 
 const getRemoveEuCountriesFromPaths = (
   showEUCountriesChecked,
   selectedCountriesISO
 ) => {
-  const euGroupDisplayed = getEuGroupDisplayed(selectedCountriesISO);
-  const allEuCountriesDisplayed = getAllEuCountriesDisplayed(
+  const euGroupDisplayed = getIsEUGroupDisplayed(selectedCountriesISO);
+  const allEuCountriesDisplayed = getAreAllEuCountriesDisplayed(
     selectedCountriesISO
   );
 
@@ -144,8 +144,8 @@ export const selectedMapCountriesISOFunction = (
   showEUCountriesChecked,
   selectedCountriesISO
 ) => {
-  const euGroupDisplayed = getEuGroupDisplayed(selectedCountriesISO);
-  const allEuCountriesDisplayed = getAllEuCountriesDisplayed(
+  const euGroupDisplayed = getIsEUGroupDisplayed(selectedCountriesISO);
+  const allEuCountriesDisplayed = getAreAllEuCountriesDisplayed(
     selectedCountriesISO
   );
 

--- a/app/javascript/app/components/ndcs/shared/selectors.js
+++ b/app/javascript/app/components/ndcs/shared/selectors.js
@@ -126,19 +126,14 @@ const getIsEUGroupDisplayed = selectedCountriesISO =>
 const getAreAllEuCountriesDisplayed = selectedCountriesISO =>
   europeanCountries.every(c => selectedCountriesISO.includes(c));
 
+export const getIsEUDisplayedFunction = selectedCountriesISO =>
+  getIsEUGroupDisplayed(selectedCountriesISO) ||
+  getAreAllEuCountriesDisplayed(selectedCountriesISO);
+
 const getRemoveEuCountriesFromPaths = (
   showEUCountriesChecked,
   selectedCountriesISO
-) => {
-  const euGroupDisplayed = getIsEUGroupDisplayed(selectedCountriesISO);
-  const allEuCountriesDisplayed = getAreAllEuCountriesDisplayed(
-    selectedCountriesISO
-  );
-
-  return (
-    !showEUCountriesChecked && (euGroupDisplayed || allEuCountriesDisplayed)
-  );
-};
+) => !showEUCountriesChecked && getIsEUDisplayedFunction(selectedCountriesISO);
 
 export const selectedMapCountriesISOFunction = (
   showEUCountriesChecked,


### PR DESCRIPTION
## Description

This PR fixes a couple bugs affecting the following pages: 
- **Explore NDCS** (`/ndcs-explore`)  
- **Explore LTS** (`/lts-explore`)  
- **Net-Zero Tracker** (`/net-zero-tracker`)  

&nbsp;

### The issues
- Map
  - EU as a region and individual EU countries not correctly highlighted
    _Eg: with location set to "World" and the "Visualize individual submissions of EU Members on the map" checkbox unchecked, the EU is not highlighted. Similarly, with the location set to "European Union (party to the UNFCCC)" and the checkbox checked, the individual EU countries are not highlighted_
- Table
  - Similarly to what happens with the map, the table is not displaying the entries correctly and is responding to the checkbox's state

&nbsp;

### Investigation  

There are two ways in which EU countries can be selected:
- By the `EUU` iso code  
- By the EU countries' respective iso codes (`PRT`, `ESP`, etc)  

`pathsWithStylesFunction` (`components/ndcs/shared/selectors.js`), responsible the paths displayed on the map as well highlighting countries/regions, does its thing based on an array of iso codes provided by `selectedCountriesISO` as well as the _"Visualize individual submissions"_ checkbox. 

There are a couple issues with this:  
- If the EU countries are selected by the `EUU` iso code, and we want to display individual submissions, we lack the list of individual EU countries' iso codes  
- If the EU countries are selected by their individual iso codes, but we want to display the EU as a whole, we lack the `EUU` iso code  
- Basing the display solely on whether or not the checkbox is checked, can break the map when it doesn't make sense to display the EU as a whole eg: the user selected a single EU country. 

Similarly, the documents displayed on the table are based on `selectedCountriesISO`. Note that this function is also used to process the data and display statistics, especially on the sidebar. There is currently no mechanism to allow us to display documents based on the checkbox's state. 

&nbsp;

### Proposed solution  

The first obvious place to manipulate the ISO in order to fix the map display would be `selectedCountriesISOFunction` (or perhaps `selectedCountriesFunction` where the list of selected countries is coming from in the first place)(`components/ndcs/shared/selectors.js`). 

However, because these functions are complex and used to parse/manipulate data to display in the pages (eg: sidebar statistics), and we really only to manipulate the ISOs for the map display, it seems less bug prone to create a map specific selector which takes the resulting ISO array and manipulates it for the map display. 

**Map**  

Addition of a `selectedMapCountriesISOFunction`, to be used by the `pathsWithStylesFunction` instead of the original function. 
It takes the list of ISOs from `selectedCountriesISO` as well as the checkbox's state, and manipulates it to address the issues described in the _Investigation_ section: 
  - If `EUU` is selected and we need to display individual countries, we:
    - remove the `EUU` iso code and add the individual countries' ISO codes  
  - If the individual ISO codes are selected but we need to display the EU as a whole:
    - remove the individual ISO codes and add the `EUU` one
  - We restrict this manipulation to only where it makes sense: when all EU countries are displayed, be it by the `EUU` iso code or their individual ones. This fixes the issue where a single EU country is selected and the checkbox breaks the display. 

**Table**  

Because the original data parsing is untouched, and we have a correct list of ISO codes to fix the map display, we can simply sync the table with the map display (which will include the checkbox's state) by simply using the new `selectedMapCountriesISOFunction` instead of `selectedCountriesISOFunction` one. 

&nbsp;

## Testing  

For each of the following:
  - `/ndcs-explore`  
  - `/lts-explore`  
  - `/net-zero-tracker`  

Test the following: 
- Set _Location_ to _World_: 
  - When the _"Visualize individual (...)"_ checkbox is unchecked, verify that:
    - the map displays the EU as a whole, correctly highlighted
    - the table contains an _"European Union"_ entry  
  - When the checkbox is checked, verify that:
    - the map displays individual EU countries  
    - the table contains the individual countries' entries
- Set _Location_ to _European Union (region)_
  - _Same as above_  
- Set _Location_ to _Top Emitters_
  - _Same as above_  
- Set _Location_ to _European Union (party to the UNFCCC)_
  - _Same as above_  
- Set _Location_ to one or more EU countries (eg: Portugal, Spain)  
  - When the checkbox is checked, verify that: 
    - The map displays the countries correctly
    - The table includes the countries' entries  
  - When the checkbox is unchecked, verify that:
    - The map and table aren't affected
      _(displaying the EU as whole doesn't make sense in this case)_  

&nbsp;

## Tracking 

[Basecamp](https://basecamp.com/1756858/projects/13795275/todos/479155492)