### PR TITLE
Fix/ndc parties inconsistency

### DIFF
--- a/app/javascript/app/components/ndcs/ndcs-explore-map/ndcs-explore-map-selectors.js
+++ b/app/javascript/app/components/ndcs/ndcs-explore-map/ndcs-explore-map-selectors.js
@@ -482,19 +482,20 @@ export const getVulnerabilityData = createSelector(
 );
 
 const getCountriesAndParties = submissions => {
+  const countriesSubmissions = submissions.filter(s => s !== europeSlug);
   const partiesNumber = submissions.length;
-  let countriesNumber = submissions.length;
+  let countriesNumber = countriesSubmissions.length;
 
-  if (!submissions.includes(europeGroupExplorerPagesSlug)) {
-    return { partiesNumber, countriesNumber };
+  if (submissions.includes(europeGroupExplorerPagesSlug)) {
+    const europeanCountriesWithSubmission = intersection(
+      europeanCountries,
+      countriesSubmissions
+    );
+
+    countriesNumber +=
+      europeanCountries.length - (europeanCountriesWithSubmission.length - 1);
   }
-  const europeanCountriesWithSubmission = intersection(
-    europeanCountries,
-    submissions
-  );
 
-  countriesNumber +=
-    europeanCountries.length - (europeanCountriesWithSubmission.length - 1) - 1; // Don't count the EUU
   return { partiesNumber, countriesNumber };
 };
 

--- a/app/javascript/app/components/ndcs/shared/selectors.js
+++ b/app/javascript/app/components/ndcs/shared/selectors.js
@@ -48,7 +48,13 @@ export const selectedCountriesFunction = (locations, regions, countries) => {
   if (!locations || !locations.length || !regions || !regions.length) {
     return countries;
   }
-  const PARTIES_MISSING_IN_WORLD_SECTION = [...NO_DOCUMENT_SUBMITTED_COUNTRIES];
+
+  const EUURegion = regions.find(r => r.iso_code3 === 'EUU');
+  // EUU as a country is not included in the WORLD section
+  const PARTIES_MISSING_IN_WORLD_SECTION = [
+    ...NO_DOCUMENT_SUBMITTED_COUNTRIES,
+    { iso: europeSlug, label: EUURegion?.label }
+  ];
   const selectedRegionsCountries = locations.reduce((acc, location) => {
     let members = acc;
     if (location.iso === 'TOP') {
@@ -82,9 +88,9 @@ export const selectedCountriesFunction = (locations, regions, countries) => {
         return false;
       });
     }
-
     return members;
   }, []);
+
   const selectedRegionsCountriesISOS = selectedRegionsCountries.map(
     c => c.iso_code3
   );


### PR DESCRIPTION
This PR attempts to fix an inconsistency on the NDC explorer between the number of parties that have submitted their new or updated NDCs on the top of the page and the one shown on the legend of the map.

- The first problem was that EUU was not recognised as a country on this count on the WORLD selection. I don't remember if we changed this status for the map. Now the WORLD selection includes EUU so its counted.

- The second problem, still not fixed, is an inconsistency on the VAT (Holy See) on different indicators. This may be a data problem. On the number on the top which comes from the 'ndce_status_2020' indicator the Holy See is counted but on the legend which comes from the 'latest submission' indicator it is on the Only First NDC category, so its not counted.


After giving it a thought Im not sure if we should depend on two different indicators to show the same number. We may want to talk to WRI about this.