### PR TITLE
Add "Last updated" to the NDC, NDC Enhancement, LTS, and Net-Zero trackers/explorers

### DIFF
--- a/app/javascript/app/components/ndcs/lts-explore-map/lts-explore-map-component.jsx
+++ b/app/javascript/app/components/ndcs/lts-explore-map/lts-explore-map-component.jsx
@@ -299,10 +299,10 @@ function LTSExploreMap(props) {
                     </div>
                     <div className={styles.containerMap}>
                       {loading && <Loading light className={styles.loader} />}
-                      <HandIconInfo
-                        className={styles.mapInfo}
-                        text="Click on a country to see an in-depth analysis of its long-term strategy"
-                      />
+                      <HandIconInfo className={styles.mapInfo}>
+                        Click on a country to see an in-depth analysis of its
+                        long-term strategy
+                      </HandIconInfo>
                       <span data-tour="lts-explore-03">
                         {renderMap({ isTablet })}
                       </span>

--- a/app/javascript/app/components/ndcs/lts-explore-map/lts-explore-map-component.jsx
+++ b/app/javascript/app/components/ndcs/lts-explore-map/lts-explore-map-component.jsx
@@ -23,6 +23,7 @@ import cx from 'classnames';
 import { getHoverIndex } from 'components/ndcs/shared/utils';
 import { SEO_PAGES } from 'data/seo';
 import SEOTags from 'components/seo-tags';
+import MetadataProvider from 'providers/metadata-provider';
 
 import layout from 'styles/layout.scss';
 import newMapTheme from 'styles/themes/map/map-new-zoom-controls.scss';
@@ -151,7 +152,8 @@ function LTSExploreMap(props) {
     handlePngDownloadModal,
     pngSelectionSubtitle,
     selectActiveDonutIndex,
-    pngDownloadId
+    pngDownloadId,
+    metadata
   } = props;
   useEffect(() => {
     selectActiveDonutIndex(0);
@@ -301,7 +303,13 @@ function LTSExploreMap(props) {
                       {loading && <Loading light className={styles.loader} />}
                       <HandIconInfo className={styles.mapInfo}>
                         Click on a country to see an in-depth analysis of its
-                        long-term strategy
+                        long-term strategy.
+                        {metadata && (
+                          <span className={styles.lastUpdated}>
+                            {' '}
+                            {metadata?.frequency_of_updates}
+                          </span>
+                        )}
                       </HandIconInfo>
                       <span data-tour="lts-explore-03">
                         {renderMap({ isTablet })}
@@ -344,6 +352,7 @@ function LTSExploreMap(props) {
           </div>
         )}
       </TabletLandscape>
+      <MetadataProvider source="ndc_lts" />
     </div>
   );
 }
@@ -375,7 +384,8 @@ LTSExploreMap.propTypes = {
   handlePngDownloadModal: PropTypes.func.isRequired,
   pngSelectionSubtitle: PropTypes.string,
   pngDownloadId: PropTypes.string.isRequired,
-  donutActiveIndex: PropTypes.number
+  donutActiveIndex: PropTypes.number,
+  metadata: PropTypes.object
 };
 
 export default LTSExploreMap;

--- a/app/javascript/app/components/ndcs/lts-explore-map/lts-explore-map-selectors.js
+++ b/app/javascript/app/components/ndcs/lts-explore-map/lts-explore-map-selectors.js
@@ -38,8 +38,10 @@ const getSearch = state => state.search || null;
 const getCategoriesData = state => state.categories || null;
 const getIndicatorsData = state => state.indicators || null;
 const getZoom = state => state.map.zoom || null;
-
 const getCountries = state => state.countries || null;
+
+export const getMetadata = state => state.metadata.data;
+
 export const getRegions = state =>
   (state && state.regions && state.regions.data) || null;
 

--- a/app/javascript/app/components/ndcs/lts-explore-map/lts-explore-map-selectors.js
+++ b/app/javascript/app/components/ndcs/lts-explore-map/lts-explore-map-selectors.js
@@ -40,7 +40,8 @@ const getIndicatorsData = state => state.indicators || null;
 const getZoom = state => state.map.zoom || null;
 const getCountries = state => state.countries || null;
 
-export const getMetadata = state => state.metadata.data;
+export const getMetadata = state =>
+  !state.metadata.loading ? state.metadata.data : null;
 
 export const getRegions = state =>
   (state && state.regions && state.regions.data) || null;

--- a/app/javascript/app/components/ndcs/lts-explore-map/lts-explore-map-styles.scss
+++ b/app/javascript/app/components/ndcs/lts-explore-map/lts-explore-map-styles.scss
@@ -253,3 +253,10 @@
   display: flex;
   font-style: italic;
 }
+
+.lastUpdated {
+  // Due to the use of AbbrReplace in HandIconInfo, the lastUpdated element brings
+  // extra text with it to a new line. This is a quick fix for that.
+  display: block;
+  white-space: nowrap;
+}

--- a/app/javascript/app/components/ndcs/lts-explore-map/lts-explore-map.js
+++ b/app/javascript/app/components/ndcs/lts-explore-map/lts-explore-map.js
@@ -31,7 +31,8 @@ import {
   getDonutActiveIndex,
   getPngSelectionSubtitle,
   getLocations,
-  getSelectedLocations
+  getSelectedLocations,
+  getMetadata
 } from './lts-explore-map-selectors';
 
 const actions = {
@@ -76,7 +77,8 @@ const mapStateToProps = (state, { location }) => {
     donutActiveIndex: getDonutActiveIndex(LTSWithSelection),
     pngSelectionSubtitle: getPngSelectionSubtitle(LTSWithSelection),
     locations: getLocations(LTSWithSelection),
-    selectedLocations: getSelectedLocations(LTSWithSelection)
+    selectedLocations: getSelectedLocations(LTSWithSelection),
+    metadata: getMetadata(LTSWithSelection)
   };
 };
 

--- a/app/javascript/app/components/ndcs/ndcs-enhancements-map/ndcs-enhancements-map-component.jsx
+++ b/app/javascript/app/components/ndcs/ndcs-enhancements-map/ndcs-enhancements-map-component.jsx
@@ -8,6 +8,7 @@ import MapLegend from 'components/map-legend';
 import ButtonGroup from 'components/button-group';
 import CountriesDocumentsProvider from 'providers/countries-documents-provider';
 import NDCSPreviousComparisonProvider from 'providers/ndcs-previous-comparison-provider';
+import MetadataProvider from 'providers/metadata-provider';
 import NdcsProvider from 'providers/ndcs-provider';
 import AbbrReplace, { replaceStringAbbr } from 'components/abbr-replace';
 import { CheckInput } from 'cw-components';
@@ -31,8 +32,7 @@ const renderButtonGroup = (
         <em>
           <AbbrReplace>
             Track which countries are submitting their national climate
-            commitments. You can compare countries’
-            submissions side by side{' '}
+            commitments. You can compare countries’ submissions side by side{' '}
             <Link to="custom-compare/overview" title="Compare submissions">
               here
             </Link>{' '}
@@ -133,7 +133,8 @@ const NDCSEnhancementsMap = ({
   handlePngDownloadModal,
   handleCountryClick,
   checked,
-  pngDownloadId
+  pngDownloadId,
+  metadata
 }) => {
   // eslint-disable-next-line react/prop-types
   const renderMap = ({ isTablet, png }) => (
@@ -204,6 +205,12 @@ const NDCSEnhancementsMap = ({
                     downloadLink,
                     handlePngDownloadModal
                   )}
+                {metadata && (
+                  <span className={styles.lastUpdated}>
+                    {' '}
+                    {metadata?.frequency_of_updates}
+                  </span>
+                )}
                 <span data-tour="ndc-enhancement-tracker-02">
                   {renderMap({ isTablet })}
                 </span>
@@ -249,6 +256,7 @@ const NDCSEnhancementsMap = ({
                 'ndce_date'
               ]}
             />
+            <MetadataProvider source="2020_ndc" />
           </div>
         )}
       </TabletLandscape>
@@ -270,7 +278,8 @@ NDCSEnhancementsMap.propTypes = {
   handlePngDownloadModal: PropTypes.func.isRequired,
   handleCountryClick: PropTypes.func.isRequired,
   checked: PropTypes.bool,
-  mapColors: PropTypes.array
+  mapColors: PropTypes.array,
+  metadata: PropTypes.object
 };
 
 export default NDCSEnhancementsMap;

--- a/app/javascript/app/components/ndcs/ndcs-enhancements-map/ndcs-enhancements-map-selectors.js
+++ b/app/javascript/app/components/ndcs/ndcs-enhancements-map/ndcs-enhancements-map-selectors.js
@@ -38,7 +38,8 @@ const getCountriesDocuments = state => state.countriesDocuments.data || null;
 
 export const getCountries = state =>
   (state.countries && state.countries.data) || null;
-export const getMetadata = state => state.metadata.data;
+export const getMetadata = state =>
+  !state.metadata.loading ? state.metadata.data : null;
 
 export const getIsEnhancedChecked = createSelector(
   getSearch,

--- a/app/javascript/app/components/ndcs/ndcs-enhancements-map/ndcs-enhancements-map-selectors.js
+++ b/app/javascript/app/components/ndcs/ndcs-enhancements-map/ndcs-enhancements-map-selectors.js
@@ -26,8 +26,6 @@ const ENHANCEMENT_SLUGS = {
 };
 
 const getSearch = state => state.search || null;
-export const getCountries = state =>
-  (state.countries && state.countries.data) || null;
 const getCategories = state =>
   (state.ndcs && state.ndcs.data && state.ndcs.data.categories) || null;
 const getIndicatorsData = state =>
@@ -37,6 +35,10 @@ const getZoom = state => state.map.zoom || null;
 const getPreviousComparisonIndicators = state =>
   state.ndcsPreviousComparison && state.ndcsPreviousComparison.data;
 const getCountriesDocuments = state => state.countriesDocuments.data || null;
+
+export const getCountries = state =>
+  (state.countries && state.countries.data) || null;
+export const getMetadata = state => state.metadata.data;
 
 export const getIsEnhancedChecked = createSelector(
   getSearch,

--- a/app/javascript/app/components/ndcs/ndcs-enhancements-map/ndcs-enhancements-map-styles.scss
+++ b/app/javascript/app/components/ndcs/ndcs-enhancements-map/ndcs-enhancements-map-styles.scss
@@ -96,8 +96,6 @@
     padding-left: calc(#{$gutter-padding} / 2);
   }
 
-  padding-top: calc(#{$gutter-padding} / 2);
-
   [class*=map-styles__wrapper] {
     &,
     &[class*=__notDraggable] {
@@ -235,4 +233,10 @@
 
 .map {
   cursor: grab;
+}
+
+.lastUpdated {
+  position: absolute;
+  white-space: nowrap;
+  font-style: italic;
 }

--- a/app/javascript/app/components/ndcs/ndcs-enhancements-map/ndcs-enhancements-map.js
+++ b/app/javascript/app/components/ndcs/ndcs-enhancements-map/ndcs-enhancements-map.js
@@ -24,6 +24,7 @@ import {
   getPreviousComparisonCountryValues,
   getCompareLinks,
   getCountries,
+  getMetadata,
   MAP_COLORS
 } from './ndcs-enhancements-map-selectors';
 
@@ -53,6 +54,7 @@ const mapStateToProps = (state, { location }) => {
     previousComparisonCountryValues: getPreviousComparisonCountryValues(
       ndcsEnhancementsWithSelection
     ),
+    metadata: getMetadata(ndcsEnhancementsWithSelection),
     mapColors: MAP_COLORS
   };
 };

--- a/app/javascript/app/components/ndcs/ndcs-explore-map/ndcs-explore-map-component.jsx
+++ b/app/javascript/app/components/ndcs/ndcs-explore-map/ndcs-explore-map-component.jsx
@@ -354,10 +354,11 @@ function NDCSExploreMap(props) {
                     </div>
                     <div className={styles.containerMap}>
                       {loading && <Loading light className={styles.loader} />}
-                      <HandIconInfo
-                        className={styles.mapInfo}
-                        text="The map reflects latest submission of each country, click on a country to see in-depth analysis of its latest NDC and previous submissions"
-                      />
+                      <HandIconInfo className={styles.mapInfo}>
+                        The map reflects latest submission of each country,
+                        click on a country to see in-depth analysis of its
+                        latest NDC and previous submissions
+                      </HandIconInfo>
                       <span data-tour="ndc-explore-04">
                         {renderMap({ isTablet })}
                       </span>

--- a/app/javascript/app/components/ndcs/ndcs-explore-map/ndcs-explore-map-component.jsx
+++ b/app/javascript/app/components/ndcs/ndcs-explore-map/ndcs-explore-map-component.jsx
@@ -33,6 +33,7 @@ import ModalShare from 'components/modal-share';
 import NDCSExploreProvider from 'providers/ndcs-explore-provider';
 import NDCSPreviousComparisonProvider from 'providers/ndcs-previous-comparison-provider';
 import DocumentsProvider from 'providers/documents-provider';
+import MetadataProvider from 'providers/metadata-provider';
 
 import { SEO_PAGES } from 'data/seo';
 
@@ -176,7 +177,8 @@ function NDCSExploreMap(props) {
     checked,
     pngDownloadId,
     secondCardSelectedTab,
-    setSecondCardSelectedTab
+    setSecondCardSelectedTab,
+    metadata
   } = props;
 
   const tooltipParentRef = useRef(null);
@@ -357,7 +359,13 @@ function NDCSExploreMap(props) {
                       <HandIconInfo className={styles.mapInfo}>
                         The map reflects latest submission of each country,
                         click on a country to see in-depth analysis of its
-                        latest NDC and previous submissions
+                        latest NDC and previous submissions.
+                        {metadata && (
+                          <span className={styles.lastUpdated}>
+                            {' '}
+                            {metadata?.frequency_of_updates}
+                          </span>
+                        )}
                       </HandIconInfo>
                       <span data-tour="ndc-explore-04">
                         {renderMap({ isTablet })}
@@ -401,6 +409,7 @@ function NDCSExploreMap(props) {
         {legendData && renderLegend(legendData, emissionsCardData, true)}
       </ModalPngDownload>
       <DocumentsProvider />
+      <MetadataProvider source="ndc_cw" />
       <React.Fragment>
         <NDCSExploreProvider
           document={selectedDocument && selectedDocument.value}
@@ -447,7 +456,8 @@ NDCSExploreMap.propTypes = {
   checked: PropTypes.bool,
   donutActiveIndex: PropTypes.number,
   secondCardSelectedTab: PropTypes.string,
-  setSecondCardSelectedTab: PropTypes.string
+  setSecondCardSelectedTab: PropTypes.string,
+  metadata: PropTypes.object
 };
 
 export default NDCSExploreMap;

--- a/app/javascript/app/components/ndcs/ndcs-explore-map/ndcs-explore-map-selectors.js
+++ b/app/javascript/app/components/ndcs/ndcs-explore-map/ndcs-explore-map-selectors.js
@@ -54,7 +54,8 @@ const getCountries = state => state.countries || null;
 const getRegions = state =>
   (state && state.regions && state.regions.data) || null;
 
-export const getMetadata = (state) => state.metadata.data;
+export const getMetadata = state =>
+  !state.metadata.loading ? state.metadata.data : null;
 
 export const getLocations = createSelector(
   [getRegions, getCountries],

--- a/app/javascript/app/components/ndcs/ndcs-explore-map/ndcs-explore-map-selectors.js
+++ b/app/javascript/app/components/ndcs/ndcs-explore-map/ndcs-explore-map-selectors.js
@@ -54,6 +54,8 @@ const getCountries = state => state.countries || null;
 const getRegions = state =>
   (state && state.regions && state.regions.data) || null;
 
+export const getMetadata = (state) => state.metadata.data;
+
 export const getLocations = createSelector(
   [getRegions, getCountries],
   (regions, countries) => {

--- a/app/javascript/app/components/ndcs/ndcs-explore-map/ndcs-explore-map-styles.scss
+++ b/app/javascript/app/components/ndcs/ndcs-explore-map/ndcs-explore-map-styles.scss
@@ -326,3 +326,7 @@
   display: flex;
   font-style: italic;
 }
+
+.lastUpdated {
+  white-space: nowrap;
+}

--- a/app/javascript/app/components/ndcs/ndcs-explore-map/ndcs-explore-map.js
+++ b/app/javascript/app/components/ndcs/ndcs-explore-map/ndcs-explore-map.js
@@ -37,7 +37,8 @@ import {
   getPngSelectionSubtitle,
   getLocations,
   getSelectedLocations,
-  getVulnerabilityData
+  getVulnerabilityData,
+  getMetadata
 } from './ndcs-explore-map-selectors';
 
 const actions = { ...modalActions, ...exploreMapActions, ...pngModalActions };
@@ -79,7 +80,8 @@ const mapStateToProps = (state, { location }) => {
     checked: getIsShowEUCountriesChecked(ndcsExploreWithSelection),
     pngSelectionSubtitle: getPngSelectionSubtitle(ndcsExploreWithSelection),
     locations: getLocations(ndcsExploreWithSelection),
-    vulnerabilityData: getVulnerabilityData(ndcsExploreWithSelection)
+    vulnerabilityData: getVulnerabilityData(ndcsExploreWithSelection),
+    metadata: getMetadata(ndcsExploreWithSelection)
   };
 };
 const pngDownloadId = 'ndcs-explore-map';

--- a/app/javascript/app/components/ndcs/net-zero-map/net-zero-map-component.jsx
+++ b/app/javascript/app/components/ndcs/net-zero-map/net-zero-map-component.jsx
@@ -300,10 +300,11 @@ function NetZeroMap(props) {
                       data-tour="net-zero-03"
                     >
                       {loading && <Loading light className={styles.loader} />}
-                      <HandIconInfo
-                        className={styles.mapInfo}
-                        text="The map reflects latest communication of each country. Explore which countries have adopted a net-zero target below and click on a country to see its climate profile."
-                      />
+                      <HandIconInfo className={styles.mapInfo}>
+                        The map reflects latest communication of each country.
+                        Explore which countries have adopted a net-zero target
+                        below and click on a country to see its climate profile.
+                      </HandIconInfo>
                       {renderMap({ isTablet })}
                       <CheckInput
                         theme={blueCheckboxTheme}

--- a/app/javascript/app/components/ndcs/net-zero-map/net-zero-map-component.jsx
+++ b/app/javascript/app/components/ndcs/net-zero-map/net-zero-map-component.jsx
@@ -24,6 +24,7 @@ import cx from 'classnames';
 import { getHoverIndex } from 'components/ndcs/shared/utils';
 import { SEO_PAGES } from 'data/seo';
 import SEOTags from 'components/seo-tags';
+import MetadataProvider from 'providers/metadata-provider';
 
 import layout from 'styles/layout.scss';
 import newMapTheme from 'styles/themes/map/map-new-zoom-controls.scss';
@@ -148,7 +149,8 @@ function NetZeroMap(props) {
     tooltipValues,
     donutActiveIndex,
     selectActiveDonutIndex,
-    pngDownloadId
+    pngDownloadId,
+    metadata
   } = props;
   useEffect(() => {
     selectActiveDonutIndex(0);
@@ -304,6 +306,12 @@ function NetZeroMap(props) {
                         The map reflects latest communication of each country.
                         Explore which countries have adopted a net-zero target
                         below and click on a country to see its climate profile.
+                        {metadata && (
+                          <span className={styles.lastUpdated}>
+                            {' '}
+                            {metadata?.frequency_of_updates}
+                          </span>
+                        )}
                       </HandIconInfo>
                       {renderMap({ isTablet })}
                       <CheckInput
@@ -344,6 +352,7 @@ function NetZeroMap(props) {
           </div>
         )}
       </TabletLandscape>
+      <MetadataProvider source="net_zero" />
     </div>
   );
 }
@@ -375,7 +384,8 @@ NetZeroMap.propTypes = {
   pngSelectionSubtitle: PropTypes.string,
   pngDownloadId: PropTypes.string.isRequired,
   selectActiveDonutIndex: PropTypes.func.isRequired,
-  donutActiveIndex: PropTypes.number
+  donutActiveIndex: PropTypes.number,
+  metadata: PropTypes.object
 };
 
 export default NetZeroMap;

--- a/app/javascript/app/components/ndcs/net-zero-map/net-zero-map-selectors.js
+++ b/app/javascript/app/components/ndcs/net-zero-map/net-zero-map-selectors.js
@@ -40,6 +40,9 @@ const getCountries = state => state.countries || null;
 const getCategoriesData = state => state.categories || null;
 const getIndicatorsData = state => state.indicators || null;
 const getZoom = state => state.map.zoom || null;
+
+export const getMetadata = state => state.metadata.data;
+
 export const getDonutActiveIndex = state =>
   state.exploreMap.activeIndex || null;
 

--- a/app/javascript/app/components/ndcs/net-zero-map/net-zero-map-selectors.js
+++ b/app/javascript/app/components/ndcs/net-zero-map/net-zero-map-selectors.js
@@ -41,7 +41,8 @@ const getCategoriesData = state => state.categories || null;
 const getIndicatorsData = state => state.indicators || null;
 const getZoom = state => state.map.zoom || null;
 
-export const getMetadata = state => state.metadata.data;
+export const getMetadata = state =>
+  !state.metadata.loading ? state.metadata.data : null;
 
 export const getDonutActiveIndex = state =>
   state.exploreMap.activeIndex || null;

--- a/app/javascript/app/components/ndcs/net-zero-map/net-zero-map-styles.scss
+++ b/app/javascript/app/components/ndcs/net-zero-map/net-zero-map-styles.scss
@@ -263,5 +263,8 @@
 }
 
 .lastUpdated {
+  // Due to the use of AbbrReplace in HandIconInfo, the lastUpdated element brings
+  // extra text with it to a new line. This is a quick fix for that.
+  display: block;
   white-space: nowrap;
 }

--- a/app/javascript/app/components/ndcs/net-zero-map/net-zero-map-styles.scss
+++ b/app/javascript/app/components/ndcs/net-zero-map/net-zero-map-styles.scss
@@ -261,3 +261,7 @@
   display: flex;
   font-style: italic;
 }
+
+.lastUpdated {
+  white-space: nowrap;
+}

--- a/app/javascript/app/components/ndcs/net-zero-map/net-zero-map.js
+++ b/app/javascript/app/components/ndcs/net-zero-map/net-zero-map.js
@@ -31,7 +31,8 @@ import {
   getDonutActiveIndex,
   getPngSelectionSubtitle,
   getLocations,
-  getSelectedLocations
+  getSelectedLocations,
+  getMetadata
 } from './net-zero-map-selectors';
 
 const actions = {
@@ -76,7 +77,8 @@ const mapStateToProps = (state, { location }) => {
     donutActiveIndex: getDonutActiveIndex(netZeroWithSelection),
     pngSelectionSubtitle: getPngSelectionSubtitle(netZeroWithSelection),
     selectedLocations: getSelectedLocations(netZeroWithSelection),
-    locations: getLocations(netZeroWithSelection)
+    locations: getLocations(netZeroWithSelection),
+    metadata: getMetadata(netZeroWithSelection)
   };
 };
 

--- a/app/javascript/app/components/ndcs/shared/hand-icon-info/hand-icon-info.jsx
+++ b/app/javascript/app/components/ndcs/shared/hand-icon-info/hand-icon-info.jsx
@@ -6,17 +6,17 @@ import AbbrReplace from 'components/abbr-replace';
 import handCursorIcon from 'assets/icons/hand-cursor.svg';
 import styles from './hand-icon-info-styles.scss';
 
-const HandIconInfo = ({ text, className }) => (
+const HandIconInfo = ({ className, children }) => (
   <p className={cx(styles.handIconInfo, className)}>
     <Icon icon={handCursorIcon} className={styles.handIcon} />
     <span>
-      <AbbrReplace>{text}</AbbrReplace>
+      <AbbrReplace>{children}</AbbrReplace>
     </span>
   </p>
 );
 
 HandIconInfo.propTypes = {
-  text: PropTypes.string,
+  children: PropTypes.node.isRequired,
   className: PropTypes.string
 };
 

--- a/app/javascript/app/pages/ndc-compare-all-targets/ndc-compare-all-targets-component.jsx
+++ b/app/javascript/app/pages/ndc-compare-all-targets/ndc-compare-all-targets-component.jsx
@@ -88,10 +88,10 @@ const NDCCompareAllTargets = props => {
         </div>
       </Header>
       <div className={cx(layout.content, styles.wrapper)}>
-        <HandIconInfo
-          className={styles.handIconInfo}
-          text="Click on up to 3 of the submitted boxes and click on the compare button."
-        />
+        <HandIconInfo className={styles.handIconInfo}>
+          Click on up to 3 of the submitted boxes and click on the compare
+          button.
+        </HandIconInfo>
         <div>
           <div className={styles.legendAndActions}>
             {renderLegend()}

--- a/app/javascript/app/providers/metadata-provider/metadata-provider-actions.js
+++ b/app/javascript/app/providers/metadata-provider/metadata-provider-actions.js
@@ -1,0 +1,31 @@
+import { createAction } from 'redux-actions';
+import { createThunkAction } from 'utils/redux';
+
+import { apiWithCache } from 'services/api';
+
+const getMetadataInit = createAction('getMetadataInit');
+const getMetadataReady = createAction('getMetadataReady');
+const getMetadataFail = createAction('getMetadataFail');
+
+const getMetadata = createThunkAction('getMetadata', props => dispatch => {
+  const { source } = props;
+
+  dispatch(getMetadataInit());
+
+  apiWithCache
+    .get(`/api/v1/metadata${source ? `/${source}` : ''}`)
+    .then(response => {
+      dispatch(getMetadataReady(response.data));
+    })
+    .catch(error => {
+      console.warn(error);
+      dispatch(getMetadataFail());
+    });
+});
+
+export default {
+  getMetadata,
+  getMetadataInit,
+  getMetadataReady,
+  getMetadataFail
+};

--- a/app/javascript/app/providers/metadata-provider/metadata-provider-reducers.js
+++ b/app/javascript/app/providers/metadata-provider/metadata-provider-reducers.js
@@ -1,0 +1,17 @@
+export const initialState = {
+  loading: false,
+  loaded: false,
+  error: false,
+  data: null
+};
+
+const setLoading = (state, loading) => ({ ...state, loading });
+const setLoaded = (state, loaded) => ({ ...state, loaded });
+const setError = (state, error) => ({ ...state, error });
+
+export default {
+  getMetadataInit: state => setLoading(state, true),
+  getMetadataReady: (state, { payload }) =>
+    setLoaded(setLoading({ ...state, data: payload }, false), true),
+  getMetadataFail: state => setError(state, true)
+};

--- a/app/javascript/app/providers/metadata-provider/metadata-provider.js
+++ b/app/javascript/app/providers/metadata-provider/metadata-provider.js
@@ -1,0 +1,24 @@
+import { useEffect } from 'react';
+import { connect } from 'react-redux';
+import PropTypes from 'prop-types';
+
+import actions from './metadata-provider-actions';
+import reducers, { initialState } from './metadata-provider-reducers';
+
+const MetadataProvider = props => {
+  const { source, getMetadata } = props;
+
+  useEffect(() => {
+    getMetadata({ source });
+  }, [source]);
+
+  return null;
+};
+
+MetadataProvider.propTypes = {
+  getMetadata: PropTypes.func.isRequired
+};
+
+export { actions, reducers, initialState };
+
+export default connect(null, actions)(MetadataProvider);

--- a/app/javascript/app/reducers.js
+++ b/app/javascript/app/reducers.js
@@ -47,6 +47,7 @@ import * as agricultureWorldMeatTradeProvider from 'providers/agriculture-world-
 import * as ndcCompareAllTargetsProvider from 'providers/ndc-compare-all-targets-provider';
 import * as customCompareAccordionProvider from 'providers/custom-compare-accordion-provider';
 import * as keyVisualizationsProvider from 'providers/key-visualizations-provider';
+import * as metadataProvider from 'providers/metadata-provider';
 
 const providersReducers = {
   ndcs: handleActions(NDCSProvider),
@@ -94,7 +95,8 @@ const providersReducers = {
   meatWorldTrade: handleActions(agricultureWorldMeatTradeProvider),
   compareAll: handleActions(ndcCompareAllTargetsProvider),
   customCompareAccordion: handleActions(customCompareAccordionProvider),
-  keyVisualizations: handleActions(keyVisualizationsProvider)
+  keyVisualizations: handleActions(keyVisualizationsProvider),
+  metadata: handleActions(metadataProvider)
 };
 
 // Pages


### PR DESCRIPTION
## Description

This PR adds the _"Last updated"_ information to the following trackers/explorers: 
- NDC Enhancement Tracker
- NDC Explorer
- Net-Zero Tracker
- LTS Explorer

&nbsp;

_"Last updated"_ is a string retrieved from [/api/v1/metadata](https://www.climatewatchdata.org/api/v1/metadata), `frequency_of_updates` property.   
Matching is as follows: 

- NDC Enhancement Tracker: `2020_ndc`
- NDC Explorer: `ndc_cw`
- Net-Zero Tracker: `net_zero`
- LTS Explorer: `ndc_lts`

&nbsp;

## Notes  

- A new `MetadataProvider` was added in order to retrieve metadata from the API  
  - It can take a `source` property in order to return a single entry (eg: [/api/v1/metadata/2020_ndc](https://www.climatewatchdata.org/api/v1/metadata/2020_ndc). If a source is not specified, it will fetch all entries (eg: [/api/v1/metadata](https://www.climatewatchdata.org/api/v1/metadata)
- Due to styling/padding, in 3 out of 4 trackers/explorers the date of last update needed to be passed to the `HandInfoIcon` component.
  - Because we do not want to wordwrap this, the component was changed to now take `children` which is used instead of the `text` property, so that it has HTML support.
  - This does not affect the usage of the `AbbrReplace` component inside `HandInfoIcon`. 
