### PR TITLE
Change every mention of LUCF to LULUCF

### DIFF
--- a/app/javascript/app/components/abbr-replace/abbr-replace-data.js
+++ b/app/javascript/app/components/abbr-replace/abbr-replace-data.js
@@ -4,7 +4,6 @@ export const SUBSCRIPTS = ['CO2', 'CH4', 'N2O', 'NF3', 'SF6'];
 export const CONFLICTS = {
   BRICS: 'BR',
   INDC: 'NDC',
-  LULUCF: 'LUCF',
   MtCO2e: 'Mt',
   UNFCCC: 'UN'
 };
@@ -47,7 +46,6 @@ export const ABBREVIATIONS = {
   IPCC: 'Intergovernmental Panel on Climate Change',
   LTS: 'Long-term Strategy',
   LULUCF: 'Land-Use, Land-Use Change and Forestry',
-  LUCF: 'Land-use Change and Forestry',
   MtCO2e: 'Million metric tonnes of carbon dioxide equivalent',
   Mt: 'Million metric tonnes',
   N2O: 'Nitrous Oxide',

--- a/app/javascript/app/components/about/about-faq/about-faq-data.js
+++ b/app/javascript/app/components/about/about-faq/about-faq-data.js
@@ -137,10 +137,6 @@ export const sectionsData = [
           },
           { Acronym: 'LTS', 'Acronym definition': 'Long-term Strategy' },
           {
-            Acronym: 'LUCF',
-            'Acronym definition': 'Land-use Change and Forestry'
-          },
-          {
             Acronym: 'LULUCF',
             'Acronym definition': 'Land-use, land-use Change and Forestry'
           },
@@ -204,7 +200,7 @@ export const sectionsData = [
             'Climate Watch':
               'The Climate Watch dataset is the most comprehensive included on Climate Watch and includes all sectors and gases. In order to emphasize comparability of data across countries, it does not use countries’ official inventories reported to the UNFCCC. It has a 3 year lag.',
             'PIK PRIMAP-hist':
-              'The PIK PRIMAP-hist dataset included on Climate Watch combines UNFCCC reported data where available and fills gaps with other sources. It does not include land use change and forestry (LUCF) but covers all other sectors and has a 3 year lag. Additional data to what is shown on Climate Watch is available from <a href="https://www.pik-potsdam.de/paris-reality-check/primap-hist/">PIK</a>.',
+              'The PIK PRIMAP-hist dataset included on Climate Watch combines UNFCCC reported data where available and fills gaps with other sources. It does not include land use change and forestry (LULUCF) but covers all other sectors and has a 3 year lag. Additional data to what is shown on Climate Watch is available from <a href="https://www.pik-potsdam.de/paris-reality-check/primap-hist/">PIK</a>.',
             UNFCCC:
               'UNFCCC includes only officially reported data by countries. It has large data gaps for non-Annex I countries. Due to different reporting requirements for Annex I and non-Annex I countries, the data is not internally comparable. It covers all sectors and has 2-3 year lag.',
             GCP:
@@ -244,7 +240,7 @@ export const sectionsData = [
             'Climate Watch':
               'Main IPCC sectors, including energy sub-sectors. Includes:<ul><li>agriculture</li><li>bunker fuels</li><li>energy<ul><li>electricity/heat</li><li>fugitive emissions</li><li>manufacturing/ construction</li><li>other fuel combustion</li><li>transportation</li></ul></li><li>industrial processes</li><li>land-use change and forestry</li><li>waste</li>',
             'PIK PRIMAP-hist':
-              'Main IPCC sectors excluding LUCF. Includes: <ul><li>agriculture</li><li>energy</li><li>industrial processes and product use</li><li>other</li><li>waste</li></ul>Excludes: <ul><li>land use change and forestry</li><li>bunker fuels</li></ul> Additional sub-sectors are included in the original source and not reflected on Climate Watch.',
+              'Main IPCC sectors excluding LULUCF. Includes: <ul><li>agriculture</li><li>energy</li><li>industrial processes and product use</li><li>other</li><li>waste</li></ul>Excludes: <ul><li>land use change and forestry</li><li>bunker fuels</li></ul> Additional sub-sectors are included in the original source and not reflected on Climate Watch.',
             UNFCCC:
               'Main IPCC sectors; energy sub-sectors are reported but not included on Climate Watch. For Annex I countries: <ul><li>agriculture</li><li>energy</li><li>industrial processes and product use</li><li>land use, land-use change, and forestry</li><li>other</li><li>waste</li></ul>Excludes: <ul><li>bunker fuels (reported separately)</li></ul>For non-Annex I countries: <ul><li>agriculture</li><li>energy</li><li>industrial processes</li><li>land-use change and forestry</li><li>other</li><li>solvent and other product use</li><li>waste</li></ul>Excludes: <ul><li>bunker fuels (reported separately)</li></ul>',
             GCP:
@@ -301,7 +297,7 @@ export const sectionsData = [
         type: 'html',
         title: 'Why do some countries have sectors with negative emissions?',
         answer:
-          '<p>The Land-use Change & Forestry (LUCF) sector can be a carbon sink or a source of emissions. Trees and other vegetation take up carbon dioxide from the atmosphere, but they also release emissions when they are cut down, burned or converted to other land uses. Depending on the balance between emissions and carbon sequestration in this sector within a country’s territory, the resulting net emissions could be positive or negative.</p><p>This WRI <a href="https://www.wri.org/insights/forests-absorb-twice-much-carbon-they-emit-each-year">article</a> has more detail on how trees contribute to carbon sequestration.</p>'
+          '<p>The Land-use Change & Forestry (LULUCF) sector can be a carbon sink or a source of emissions. Trees and other vegetation take up carbon dioxide from the atmosphere, but they also release emissions when they are cut down, burned or converted to other land uses. Depending on the balance between emissions and carbon sequestration in this sector within a country’s territory, the resulting net emissions could be positive or negative.</p><p>This WRI <a href="https://www.wri.org/insights/forests-absorb-twice-much-carbon-they-emit-each-year">article</a> has more detail on how trees contribute to carbon sequestration.</p>'
       },
       {
         type: 'html',

--- a/app/javascript/app/components/country/country-emission-drivers/country-emission-drivers-component.jsx
+++ b/app/javascript/app/components/country/country-emission-drivers/country-emission-drivers-component.jsx
@@ -43,7 +43,7 @@ function CountryEmissionDrivers(props) {
             <AbbrReplace>
               <p>
                 The following indicators show representative emissions drivers
-                from the energy, agriculture and LUCF sectors and their
+                from the energy, agriculture and LULUCF sectors and their
                 respective ranking compared to other countries.
               </p>
             </AbbrReplace>

--- a/app/javascript/app/components/sectors-agriculture/drivers-of-emissions/card-pie-chart/card-pie-chart-component.jsx
+++ b/app/javascript/app/components/sectors-agriculture/drivers-of-emissions/card-pie-chart/card-pie-chart-component.jsx
@@ -83,7 +83,7 @@ class CardPieChart extends PureComponent {
     const totalIncludingLUCF = pieChartData && pieChartData.totalIncludingLUCF;
     const totalExcludingLUCF = pieChartData && pieChartData.totalExcludingLUCF;
     const subtitle = pieChartData
-      ? `${location} GHG emissions by sector in ${year} (excluding LUCF). Source: Climate Watch.`
+      ? `${location} GHG emissions by sector in ${year} (excluding LULUCF). Source: Climate Watch.`
       : 'Source: Climate Watch.';
 
     const cardTheme = {
@@ -112,7 +112,7 @@ class CardPieChart extends PureComponent {
                 <span>
                   {agricultureEmissions.includingLUCF.formattedPercentage}
                 </span>{' '}
-                including LUCF ({renderEmissionValue(totalIncludingLUCF)})
+                including LULUCF ({renderEmissionValue(totalIncludingLUCF)})
               </p>
               <TabletLandscape>
                 {this.renderAgricultureLabel()}

--- a/app/javascript/app/components/sectors-agriculture/drivers-of-emissions/card-pie-chart/pie-chart-selectors.js
+++ b/app/javascript/app/components/sectors-agriculture/drivers-of-emissions/card-pie-chart/pie-chart-selectors.js
@@ -9,8 +9,8 @@ import { format } from 'd3-format';
 import getIsoCode from './location-selectors';
 
 const AGRICULTURE_COLOR = '#0677B3';
-const TOTAL_EXCLUDING_LUCF = 'Total excluding LUCF';
-const TOTAL_INCLUDING_LUCF = 'Total including LUCF';
+const TOTAL_EXCLUDING_LUCF = 'Total excluding LULUCF';
+const TOTAL_INCLUDING_LUCF = 'Total including LULUCF';
 const INCLUDED_SECTORS = [
   'Agriculture',
   'Energy',

--- a/app/javascript/app/data/constants.js
+++ b/app/javascript/app/data/constants.js
@@ -97,7 +97,7 @@ export const DATA_SCALE = 1000000;
 export const DEFAULT_EMISSIONS_SELECTIONS = {
   'Climate Watch': {
     gas: 'All GHG',
-    sector: 'Total including LUCF',
+    sector: 'Total including LULUCF',
     location: 'WORLD'
   },
   PIK: {
@@ -112,7 +112,7 @@ export const DEFAULT_EMISSIONS_SELECTIONS = {
   },
   UNFCCC_NAI: {
     gas: 'Aggregate GHGs',
-    sector: 'Total GHG emissions including LULUCF/LUCF',
+    sector: 'Total GHG emissions including LULUCF',
     location: 'TOP'
   },
   GCP: {
@@ -122,7 +122,7 @@ export const DEFAULT_EMISSIONS_SELECTIONS = {
   },
   US: {
     gas: 'All GHG',
-    sector: 'Total including LUCF',
+    sector: 'Total including LULUCF',
     location: 'USA'
   }
 };

--- a/app/javascript/app/data/data-explorer-constants.js
+++ b/app/javascript/app/data/data-explorer-constants.js
@@ -77,7 +77,7 @@ export const FILTER_DEFAULTS = {
     'data-sources': 'Climate Watch',
     regions: ALL_SELECTED,
     gases: 'All GHG',
-    sectors: 'Total including LUCF'
+    sectors: 'Total including LULUCF'
   },
   'ndc-content': {
     categories: 'UNFCCC Process',

--- a/app/javascript/app/pages/country/country-header/country-header-selectors.js
+++ b/app/javascript/app/pages/country/country-header/country-header-selectors.js
@@ -52,7 +52,7 @@ export const getEmissionProviderFilters = createSelector(
     const allGhgGas = meta.gas.find(g => g.label === 'All GHG');
     const source = meta.data_source.find(g => g.name === 'Climate Watch');
     const TotalExcludingLucfSector = meta.sector.find(
-      g => g.label === 'Total including LUCF'
+      g => g.label === 'Total including LULUCF'
     );
     return {
       gas: allGhgGas && allGhgGas.value,

--- a/app/javascript/app/pages/sectors-agriculture/sectors-agricuture-selectors.js
+++ b/app/javascript/app/pages/sectors-agriculture/sectors-agricuture-selectors.js
@@ -7,7 +7,7 @@ const getGhgEmissionsData = state =>
   (state.emissions && state.emissions.data) || null;
 
 const AGRICULTURE_SECTOR = 'Agriculture';
-const TOTAL_SECTOR = 'Total excluding LUCF';
+const TOTAL_SECTOR = 'Total excluding LULUCF';
 
 export const getAnchorLinks = createSelector([getSections], sections =>
   sections.filter(route => route.anchor).map(route => ({


### PR DESCRIPTION
## Overview

This PR changes every mention of _"LUCF"_ to _"LULUFC"_ throughout the app. 

This is the FE counterpart to the changes already made in the data, which would cause certain parts/modules of the app to not function correctly, namely: 

- GHG Emissions module showing no data  
- Country specific donut and bar charts not showing  
- Agriculture module not displaying the donut chart  
- Data explorer showing no data

**Note:**  
A few more sections may be still non-functional or defective, due to a separate INDC data bug. 


## Tracking

[Basecamp](https://basecamp.com/1756858/projects/13795275/todos/488210347)