### PR TITLE
Faq html parsing

### DIFF
--- a/app/javascript/app/components/about/about-faq/about-faq-data.js
+++ b/app/javascript/app/components/about/about-faq/about-faq-data.js
@@ -378,7 +378,7 @@ export const sectionsData = [
           'Searching for a word in English will produce results only among I/NDCs that are in English; similarly searching for a word in French would produce results among I/NDCs in French. '
       },
       {
-        type: 'text',
+        type: 'html',
         title:
           'How do we determine enhanced ambition/overall comparison with previous NDC? ',
         answer:
@@ -484,8 +484,7 @@ export const sectionsData = [
       {
         type: 'text',
         title: 'How frequently is the data updated? ',
-        answer:
-          'NDC-SDG linkages data cover NDCs submitted prior to May 2021.'
+        answer: 'NDC-SDG linkages data cover NDCs submitted prior to May 2021.'
       },
       {
         type: 'html',

--- a/app/javascript/app/components/ndcs/ndcs-enhancements-map/ndcs-enhancements-map-component.jsx
+++ b/app/javascript/app/components/ndcs/ndcs-enhancements-map/ndcs-enhancements-map-component.jsx
@@ -33,7 +33,11 @@ const renderButtonGroup = (
           <AbbrReplace>
             Track which countries are submitting their national climate
             commitments. You can compare countries’ submissions side by side{' '}
-            <Link to="custom-compare/overview" title="Compare submissions">
+            <Link
+              to="custom-compare/overview"
+              title="Compare submissions"
+              target="_blank"
+            >
               here
             </Link>{' '}
             or by referring to the table below. To request changes or additions,


### PR DESCRIPTION
## Overview 

In this PR: 
- Fixes HTML not being parsed in one of the FAQ entries  
- Makes it so that, when on the Enhancement Tracker, clicking the link that opens the comparison tool opens it in a new page