### PR TITLE
Fix embed url generation for components embedded with the old contained method

### DIFF
--- a/app/javascript/app/components/modal-share/modal-share.js
+++ b/app/javascript/app/components/modal-share/modal-share.js
@@ -14,7 +14,8 @@ const mapStateToProps = (state, { shouldEmbedQueryParams = true }) => {
   const { isOpen: isModalOpen, sharePath } = state.modalShare;
   const { origin, pathname, search, hash } = location;
   const queryParams = shouldEmbedQueryParams ? search + hash : '';
-  const embedUri = `/embed${sharePath || pathname.replace('/embed', '')}`;
+  const embedUri = `/embed${sharePath ||
+    pathname.replace('/embed', '').replace('/contained', '')}`;
   const url = `${origin}${embedUri}${encodeURIComponent(queryParams)}`;
   const copyUrl = () => copy(url);
   const iframeCode = `<iframe src="${url}" frameborder="0" style="height: 600px; width: 1230px"></iframe>`;

--- a/app/javascript/app/layouts/embed/embed-component.jsx
+++ b/app/javascript/app/layouts/embed/embed-component.jsx
@@ -13,7 +13,9 @@ import styles from './embed-styles.scss';
 class Embed extends PureComponent {
   render() {
     const { route, location } = this.props;
-    const link = location.pathname.replace('/embed', '');
+    const link = location.pathname
+      .replace('/embed', '')
+      .replace('/contained', '');
     const isNdcp = isPageNdcp(location);
     return (
       <div className={cx(styles.embed, { [styles.embedNdcp]: isNdcp })}>


### PR DESCRIPTION
## Overview  

When components are embedded with the old `contained` "method", the _Share_ button in those embedded components is not generating the correct url. This PR fixes that. 

## Tracking  

Basecamp: https://basecamp.com/1756858/projects/13795275/todos/493617470