### PR TITLE
Rename 2025 ndc tracker urls

### DIFF
--- a/app/javascript/app/components/ndcs/ndcs-enhancements-2025-tracker-chart/ndcs-enhancements-2025-tracker-chart-component.jsx
+++ b/app/javascript/app/components/ndcs/ndcs-enhancements-2025-tracker-chart/ndcs-enhancements-2025-tracker-chart-component.jsx
@@ -233,7 +233,7 @@ const Ndc2025TrackerChartComponent = props => {
                 },
                 {
                   type: 'share',
-                  shareUrl: '/embed/2025-ndc-tracker',
+                  shareUrl: '/embed/ndc-tracker',
                   analyticsGraphName: 'Ndcs',
                   positionRight: true
                 },

--- a/app/javascript/app/components/ndcs/ndcs-enhancements-2025-tracker-chart/ndcs-enhancements-2025-tracker-chart-component.jsx
+++ b/app/javascript/app/components/ndcs/ndcs-enhancements-2025-tracker-chart/ndcs-enhancements-2025-tracker-chart-component.jsx
@@ -182,7 +182,7 @@ const Ndc2025TrackerChartComponent = props => {
 
   // Generate data explorer link
   const downloadLink = generateLinkToDataExplorer(
-    { category: '2025_ndc_tracker' },
+    { category: 'ndc_tracker' },
     'ndc-content'
   );
 

--- a/app/javascript/app/data/data-explorer-constants.js
+++ b/app/javascript/app/data/data-explorer-constants.js
@@ -143,11 +143,11 @@ export const DATA_EXPLORER_SECTIONS = {
     linkLabel: 'net-zero-tracker',
     linkName: 'net-zero-tracker'
   },
-  '2025-nds-tracker': {
-    label: '2025_ndc_tracker',
-    moduleName: '2025-ndc-tracker',
-    linkLabel: '2025_ndc_tracker',
-    linkName: '2025-ndc-tracker'
+  'ndc-tracker': {
+    label: 'ndc_tracker',
+    moduleName: 'ndc-tracker',
+    linkLabel: 'ndc_tracker',
+    linkName: 'ndc-tracker'
   }
 };
 

--- a/app/javascript/app/routes/app-routes/NDCS-routes/NDCS-routes.js
+++ b/app/javascript/app/routes/app-routes/NDCS-routes/NDCS-routes.js
@@ -24,7 +24,7 @@ export default [
     activeId
   },
   // {
-  //   path: '/2025-ndc-tracker',
+  //   path: '/ndc-tracker',
   //   label: 'NDC Tracker',
   //   activeId
   // },

--- a/app/javascript/app/routes/app-routes/app-routes.js
+++ b/app/javascript/app/routes/app-routes/app-routes.js
@@ -184,7 +184,7 @@ export default [
     headerGradient: HEADER_GRADIENTS.commitments
   },
   {
-    path: '/2025-ndc-tracker',
+    path: '/ndc-tracker',
     component: NDCSEnhancements2025,
     headerImage: 'ndc',
     sections: ndcsEnhancements2025Sections,

--- a/app/javascript/app/routes/embed-routes/embed-routes.js
+++ b/app/javascript/app/routes/embed-routes/embed-routes.js
@@ -29,7 +29,7 @@ export default [
     exact: true
   },
   {
-    path: '/embed/2025-ndc-tracker',
+    path: '/embed/ndc-tracker',
     component: NDCS2025EnhancementsMap,
     exact: true
   },


### PR DESCRIPTION
This PR is being fast-tracked to production due to the urgency; it'll be pulled back into staging afterwards. 

This is because staging contains quite a bit of unreleased code that needs a careful pair of eyes to pick out the changes. 