### PR TITLE
[N/A] US amendments

### DIFF
--- a/app/javascript/app/components/country/country-ndc-overview/country-ndc-overview-component.jsx
+++ b/app/javascript/app/components/country/country-ndc-overview/country-ndc-overview-component.jsx
@@ -170,7 +170,7 @@ function CountryNdcOverview(props) {
               <div className={styles.header}>
                 {renderIntro()}
                 {iso === 'USA' && (
-                  <p style={{ marginBottom: 10, fontWeight: 600 }}>
+                  <p className={styles.descriptionNote}>
                     On 20, January, 2025, the United States withdrew from the
                     Paris Agreement and no longer has an active NDC under the
                     UNFCCC. The NDC-related information on this NDC Page refers

--- a/app/javascript/app/components/country/country-ndc-overview/country-ndc-overview-component.jsx
+++ b/app/javascript/app/components/country/country-ndc-overview/country-ndc-overview-component.jsx
@@ -169,6 +169,15 @@ function CountryNdcOverview(props) {
             <div className="grid-column-item">
               <div className={styles.header}>
                 {renderIntro()}
+                {iso === 'USA' && (
+                  <p style={{ marginBottom: 10, fontWeight: 600 }}>
+                    On 20, January, 2025, the United States withdrew from the
+                    Paris Agreement and no longer has an active NDC under the
+                    UNFCCC. The NDC-related information on this NDC Page refers
+                    to the United States latest submitted NDC (December 19,
+                    2024) despite it being no longer active.
+                  </p>
+                )}
                 <TabletPortraitOnly>{description}</TabletPortraitOnly>
               </div>
               <TabletLandscape>{description}</TabletLandscape>

--- a/app/javascript/app/components/country/country-ndc-overview/country-ndc-overview-styles.scss
+++ b/app/javascript/app/components/country/country-ndc-overview/country-ndc-overview-styles.scss
@@ -47,6 +47,11 @@
   @include xy-gutters($gutter-position: ('bottom'));
 }
 
+.descriptionNote {
+  font-weight: $font-weight-semi-bold;
+  padding: 0 0 38px;
+}
+
 .subtitles {
   @include columns((9, 3));
 }

--- a/app/javascript/app/components/map-legend/map-legend-component.jsx
+++ b/app/javascript/app/components/map-legend/map-legend-component.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import cx from 'classnames';
 import { getColorByIndex } from 'utils/map';
+import { CHART_COLORS } from 'data/constants';
 
 import styles from './map-legend-styles.scss';
 
@@ -16,11 +17,10 @@ const renderBuckets = (buckets, mapColors) => {
       <span
         className={styles.bucketIcon}
         style={{
-          backgroundColor: getColorByIndex(
-            buckets,
-            buckets[key].index,
-            mapColors
-          )
+          backgroundColor:
+            key === 'withdrawn-ndc'
+              ? CHART_COLORS[3]
+              : getColorByIndex(buckets, buckets[key].index, mapColors)
         }}
       />
       <span className={styles.bucketTxt}>{buckets[key].name}</span>

--- a/app/javascript/app/components/ndcs/ndcs-enhancements-2025-map/ndcs-enhancements-2025-map-selectors.js
+++ b/app/javascript/app/components/ndcs/ndcs-enhancements-2025-map/ndcs-enhancements-2025-map-selectors.js
@@ -17,7 +17,8 @@ import {
   ENHANCEMENT_CATEGORIES,
   ENHANCEMENT_LABEL_SLUGS,
   NDC_2025_LABEL_COLORS,
-  INDICATOR_SLUGS
+  INDICATOR_SLUGS,
+  CHART_COLORS
 } from 'data/constants';
 
 const NDC_2025_SLUGS = {
@@ -206,12 +207,15 @@ export const reduceLegendBuckets = createSelector(
       updatedIndicator.legendBuckets
     ).reduce((acc, [key, value]) => {
       if (value.name === 'No Information') {
-        acc[key] = { ...value, name: 'No New NDC' };
+        acc[key] = { ...value, name: 'No New NDC', order: 2 };
       } else if (value.name === 'Submitted 2025 NDC') {
-        acc[key] = { ...value, name: 'New NDC' };
+        acc[key] = { ...value, name: 'New NDC', order: 1 };
       } else {
         acc[key] = value;
       }
+
+      acc['withdrawn-ndc'] = { ...value, name: 'Withdrawn NDC', order: 4 };
+
       return acc;
     }, {});
 
@@ -222,6 +226,8 @@ export const reduceLegendBuckets = createSelector(
         acc[key] = { ...value, name: 'No New NDC' };
       } else if (value.name === 'Submitted 2025 NDC') {
         acc[key] = { ...value, name: 'New NDC' };
+      } else if (value.name === 'Withdrawn NDC') {
+        acc[key] = { ...value, name: 'Withdrawn NDC' };
       } else {
         acc[key] = value;
       }
@@ -237,7 +243,12 @@ export const sortIndicatorLegend = createSelector(
   indicator => {
     if (!indicator) return null;
     const updatedIndicator = { ...indicator };
-    const namesLegendOrder = ['New NDC', 'No New NDC', 'Not Applicable'];
+    const namesLegendOrder = [
+      'New NDC',
+      'Withdrawn NDC',
+      'No New NDC',
+      'Not Applicable'
+    ];
     const updatedLegendBuckets = {};
 
     Object.entries(updatedIndicator.legendBuckets).forEach(([key, value]) => {
@@ -289,19 +300,21 @@ export const getPathsWithStyles = createSelector(
         if (countryData && countryData.label_id) {
           const legendIndex = legendBuckets[countryData.label_id].index;
           const color = getColorByIndex(legendBuckets, legendIndex, MAP_COLORS);
+
+          const fill = iso === 'USA' ? CHART_COLORS[3] : color;
           style = {
             ...COUNTRY_STYLES,
             default: {
               ...COUNTRY_STYLES.default,
               strokeWidth,
-              fill: color,
+              fill,
               fillOpacity: 1
             },
             hover: {
               ...COUNTRY_STYLES.hover,
               cursor: 'pointer',
               strokeWidth,
-              fill: color,
+              fill,
               fillOpacity: 1
             }
           };

--- a/app/javascript/app/components/ndcs/ndcs-enhancements-2025-map/ndcs-enhancements-2025-map.js
+++ b/app/javascript/app/components/ndcs/ndcs-enhancements-2025-map/ndcs-enhancements-2025-map.js
@@ -98,7 +98,7 @@ class NDCSEnhancements2025MapContainer extends PureComponent {
 
       return {
         label: this.getTooltipLabel(),
-        value,
+        value: id === 'USA' ? 'Withdrawn NDC' : value,
         statement,
         note:
           'Click on the country or see table below to compare with previous NDC',

--- a/app/javascript/app/components/ndcs/ndcs-enhancements-2025-table/ndcs-enhancements-2025-table.js
+++ b/app/javascript/app/components/ndcs/ndcs-enhancements-2025-table/ndcs-enhancements-2025-table.js
@@ -4,6 +4,7 @@ import { withRouter } from 'react-router';
 import PropTypes from 'prop-types';
 import qs from 'query-string';
 import { getLocationParamUpdated } from 'utils/navigation';
+import { CHART_COLORS } from 'data/constants';
 
 import Component from './ndcs-enhancements-2025-table-component';
 
@@ -25,6 +26,21 @@ const mapStateToProps = (state, { location }) => {
     query: search.search,
     search
   };
+
+  const tableData = replaceAbbreviations(ndcsEnhancementsWithSelection);
+
+  const USAIndex = tableData?.findIndex(d => d.country.includes('USA'));
+
+  if (USAIndex > -1) {
+    tableData[USAIndex] = {
+      ...tableData[USAIndex],
+      'NDC Status': {
+        ...tableData[USAIndex]['NDC Status'],
+        text: 'Withdrawn NDC',
+        color: CHART_COLORS[3]
+      }
+    };
+  }
 
   return {
     loading: loading || getLoadingCompareLinks(ndcsEnhancementsWithSelection),

--- a/app/javascript/app/components/ndcs/ndcs-enhancements-2025-tracker-chart/ndcs-enhancements-2025-tracker-chart-component.jsx
+++ b/app/javascript/app/components/ndcs/ndcs-enhancements-2025-tracker-chart/ndcs-enhancements-2025-tracker-chart-component.jsx
@@ -59,10 +59,14 @@ const Ndc2025TrackerChartComponent = props => {
   };
 
   // Helper to select the correct fill style for the bar colors
-  const getCountrySubmissionTypeKey = country =>
-    Object.keys(SUBMISSION_TYPES).find(
-      key => SUBMISSION_TYPES[key] === country.indc_submission
-    ) || 'notSubmitted';
+  const getCountrySubmissionTypeKey = country => {
+    if (country?.iso === 'USA') return 'withdrawn';
+    return (
+      Object.keys(SUBMISSION_TYPES).find(
+        key => SUBMISSION_TYPES[key] === country.indc_submission
+      ) || 'notSubmitted'
+    );
+  };
 
   // Parse data in order to include the `emissions` property in a number format
   const parsedData = React.useMemo(() =>

--- a/app/javascript/app/components/ndcs/ndcs-enhancements-2025-tracker-chart/ndcs-enhancements-2025-tracker-chart-component.jsx
+++ b/app/javascript/app/components/ndcs/ndcs-enhancements-2025-tracker-chart/ndcs-enhancements-2025-tracker-chart-component.jsx
@@ -380,6 +380,7 @@ const Ndc2025TrackerChartComponent = props => {
                     </p>
                     <p>
                       <span>{hoveredBar?.indc_submission}</span>
+                      {hoveredBar?.iso === 'USA' && <p>Withdrawn NDC</p>}
                     </p>
                   </div>
                 )}

--- a/app/javascript/app/components/ndcs/ndcs-enhancements-2025-tracker-chart/ndcs-enhancements-2025-tracker-chart-component.jsx
+++ b/app/javascript/app/components/ndcs/ndcs-enhancements-2025-tracker-chart/ndcs-enhancements-2025-tracker-chart-component.jsx
@@ -379,8 +379,11 @@ const Ndc2025TrackerChartComponent = props => {
                       GHG Emissions: <span>{hoveredBar?.ndce_ghg}</span>
                     </p>
                     <p>
-                      <span>{hoveredBar?.indc_submission}</span>
-                      {hoveredBar?.iso === 'USA' && <p>Withdrawn NDC</p>}
+                      {hoveredBar?.iso !== 'USA' ? (
+                        <span>{hoveredBar?.indc_submission}</span>
+                      ) : (
+                        <span>Withdrawn NDC</span>
+                      )}
                     </p>
                   </div>
                 )}

--- a/app/javascript/app/components/ndcs/ndcs-enhancements-2025-tracker-chart/ndcs-enhancements-2025-tracker-chart-styles.scss
+++ b/app/javascript/app/components/ndcs/ndcs-enhancements-2025-tracker-chart/ndcs-enhancements-2025-tracker-chart-styles.scss
@@ -219,6 +219,11 @@
 //   stroke: $white;
 // }
 
+.withdrawn {
+  fill: $chart-color-4;
+  stroke: $white;
+}
+
 .submitted2025 {
   fill: $chart-color-2;
   stroke: $white;

--- a/app/javascript/app/components/ndcs/shared/selectors.js
+++ b/app/javascript/app/components/ndcs/shared/selectors.js
@@ -5,6 +5,7 @@ import {
   COUNTRY_STYLES
 } from 'components/ndcs/shared/constants';
 import { getColorByIndex, shouldShowPath } from 'utils/map';
+import { CHART_COLORS } from 'data/constants';
 
 export const getColorException = (indicator, label) => {
   if (indicator.value !== 'child_sensitive_NDC') return null;
@@ -252,7 +253,7 @@ export const pathsWithStylesFunction = (
         const color =
           getColorException(indicator, label) ||
           getColorByIndex(legendBuckets, label.index);
-        style.default.fill = color;
+        style.default.fill = iso === 'USA' ? CHART_COLORS[9] : color;
         style.hover.fill = color;
       }
 

--- a/app/javascript/app/data/constants.js
+++ b/app/javascript/app/data/constants.js
@@ -563,6 +563,7 @@ export const NDC_2025_COLORS = {
 
 export const LEGEND_STATUS_2025_VALUES_COLORS = {
   'New NDC': NDC_2025_LABEL_COLORS.SUBMITTED_2025,
+  'Withdrawn NDC': CHART_COLORS[3],
   'No New NDC': NDC_2025_LABEL_COLORS.NO_SUBMISSION,
   'Not Applicable: Countries that are not a Party to the UNFCCC':
     NDC_2025_COLORS.lightGray
@@ -619,5 +620,6 @@ export const COMPARISON_2025_INDICATORS_LABELS = {
   '2025_compare_2': 'Economy-wide (for 2035) GHG target included',
   '2025_compare_3': 'Strengthened or added policies and actions',
   '2025_compare_4': 'Strengthened Adaptation',
-  '2025_compare_5': 'Provided additional Information for clarity, transparency, and understanding'
+  '2025_compare_5':
+    'Provided additional Information for clarity, transparency, and understanding'
 };

--- a/app/javascript/app/pages/country/country-header/country-header-component.jsx
+++ b/app/javascript/app/pages/country/country-header/country-header-component.jsx
@@ -81,7 +81,11 @@ function CountryHeader(props) {
       <div className={styles.headerContainer}>
         <div className={styles.mainContent}>
           <div className={styles.header}>
-            <Intro title={country.name} description={description} />
+            <Intro
+              title={country.name}
+              description={description}
+              skipAbbrReplace
+            />
             {Object.keys(EXTERNAL_COUNTRY_LINKS).includes(
               country.name.toLowerCase()
             ) && renderExternalLink}

--- a/app/javascript/app/pages/country/country-header/country-header-selectors.js
+++ b/app/javascript/app/pages/country/country-header/country-header-selectors.js
@@ -99,7 +99,7 @@ export const getDescriptionText = createSelector(
         </p>
         {iso === 'USA' && (
           <p>
-            On [day, month, year], the United States{' '}
+            On 20, January, 2025, the United States{' '}
             <span className={styles.bold}>
               withdrew from the Paris Agreement and no longer has an active NDC
               under the UNFCC.

--- a/app/javascript/app/pages/country/country-header/country-header-selectors.js
+++ b/app/javascript/app/pages/country/country-header/country-header-selectors.js
@@ -84,16 +84,31 @@ export const getDescriptionText = createSelector(
       ? emissionsData.emissions[emissionsData.emissions.length - 1]
       : {};
     const percentage = isoData && isoData.value;
+
     return ReactDOMServer.renderToString(
       <div className={styles.introDescription}>
-        In {lastYear}, {countryName} emitted
-        <span className={styles.bold}>
-          {' '}
-          {emissionValue && Math.round(emissionValue * 100) / 100} million
-          tonnes
-        </span>{' '}
-        of CO<sub>2</sub> equivalent representing{' '}
-        <span className={styles.bold}>{percentage} of global emissions</span>
+        <p>
+          In {lastYear}, {countryName} emitted
+          <span className={styles.bold}>
+            {' '}
+            {emissionValue && Math.round(emissionValue * 100) / 100} million
+            tonnes
+          </span>{' '}
+          of CO<sub>2</sub> equivalent representing{' '}
+          <span className={styles.bold}>{percentage} of global emissions</span>
+        </p>
+        {iso === 'USA' && (
+          <p>
+            On [day, month, year], the United States{' '}
+            <span className={styles.bold}>
+              withdrew from the Paris Agreement and no longer has an active NDC
+              under the UNFCC.
+            </span>{' '}
+            The NDC-related information on this country profile refers to the
+            United States latest submitted NDC (December 19, 2024) despite it
+            being no longer active.
+          </p>
+        )}
       </div>
     );
   }

--- a/app/javascript/app/pages/country/country-header/country-header-styles.scss
+++ b/app/javascript/app/pages/country/country-header/country-header-styles.scss
@@ -48,6 +48,10 @@
 .introDescription {
   font-size: $font-size-m;
   font-weight: $font-weight-light;
+
+  p + p {
+    padding-top: 30px;
+  }
 }
 
 .bold {


### PR DESCRIPTION
**NOTE:** The date The date used in the changes (January 20th may need to be adjusted. )

-----

This pull request includes several changes to the NDC (Nationally Determined Contributions) components and related files to handle the withdrawal of the USA from the Paris Agreement. The most important changes include adding a specific message for the USA's withdrawal, updating the map legend and table to reflect the new status, and ensuring consistent styling for the withdrawn NDC status.

Updates to handle USA withdrawal:

* [`app/javascript/app/components/country/country-ndc-overview/country-ndc-overview-component.jsx`](diffhunk://#diff-7001c6add963e7951084a436c2499133f8b88d1bf5aee3be4718812381816398R172-R180): Added a message to indicate that the USA withdrew from the Paris Agreement and no longer has an active NDC.

Map legend and table updates:

* [`app/javascript/app/components/map-legend/map-legend-component.jsx`](diffhunk://#diff-1994c3091d00669d5db7c39ecb5e90d8b96d27f34c0ff144270bb72a9aaafd41R5): Updated the legend to include a new color for withdrawn NDCs and used `CHART_COLORS` for consistent color assignment. [[1]](diffhunk://#diff-1994c3091d00669d5db7c39ecb5e90d8b96d27f34c0ff144270bb72a9aaafd41R5) [[2]](diffhunk://#diff-1994c3091d00669d5db7c39ecb5e90d8b96d27f34c0ff144270bb72a9aaafd41L19-R23)
* [`app/javascript/app/components/ndcs/ndcs-enhancements-2025-map/ndcs-enhancements-2025-map-selectors.js`](diffhunk://#diff-e635a77bc89d92a7304d26143a3efdca9350f644592c0ae4295e9314d06a865cL209-R218): Added a new legend bucket for withdrawn NDCs and updated the sorting order to include this new status. [[1]](diffhunk://#diff-e635a77bc89d92a7304d26143a3efdca9350f644592c0ae4295e9314d06a865cL209-R218) [[2]](diffhunk://#diff-e635a77bc89d92a7304d26143a3efdca9350f644592c0ae4295e9314d06a865cR229-R230) [[3]](diffhunk://#diff-e635a77bc89d92a7304d26143a3efdca9350f644592c0ae4295e9314d06a865cL240-R251) [[4]](diffhunk://#diff-e635a77bc89d92a7304d26143a3efdca9350f644592c0ae4295e9314d06a865cR303-R317)
* [`app/javascript/app/components/ndcs/ndcs-enhancements-2025-table/ndcs-enhancements-2025-table.js`](diffhunk://#diff-8a061d9af6f4bb7e2801d582c5900629dfcee15e4858cb2e922b0b53008eac70R7): Updated the table data to reflect the withdrawn NDC status for the USA, including color updates. [[1]](diffhunk://#diff-8a061d9af6f4bb7e2801d582c5900629dfcee15e4858cb2e922b0b53008eac70R7) [[2]](diffhunk://#diff-8a061d9af6f4bb7e2801d582c5900629dfcee15e4858cb2e922b0b53008eac70R30-R44)

Consistent styling and constants:

* [`app/javascript/app/data/constants.js`](diffhunk://#diff-3093ef66e9df3958ff2ca366dd52ac427115cf97335ba8118e6716b7a42a4878R566): Added a new color for the withdrawn NDC status in the `LEGEND_STATUS_2025_VALUES_COLORS` constant.
* [`app/javascript/app/components/ndcs/shared/selectors.js`](diffhunk://#diff-483f21c12476db00554bef84643897d9cf6df1b74baf893c3024988a94dcd2afR8): Used `CHART_COLORS` for consistent styling of the withdrawn NDC status in maps and charts. [[1]](diffhunk://#diff-483f21c12476db00554bef84643897d9cf6df1b74baf893c3024988a94dcd2afR8) [[2]](diffhunk://#diff-483f21c12476db00554bef84643897d9cf6df1b74baf893c3024988a94dcd2afL255-R256)